### PR TITLE
Improve overall UI for org-portal

### DIFF
--- a/apps/org-portal/src/app.css
+++ b/apps/org-portal/src/app.css
@@ -187,6 +187,11 @@
 		margin: 0 auto;
 	}
 
+	.bleed-wide {
+		width: min(100vw - 2rem, 60rem);
+		margin-inline: calc(50% - min(50vw - 1rem, 30rem));
+	}
+
 	.site-header-inner {
 		@apply flex flex-wrap items-center gap-4 justify-between;
 	}

--- a/apps/org-portal/src/app.css
+++ b/apps/org-portal/src/app.css
@@ -1,9 +1,11 @@
 @import "tailwindcss";
 @source "../../../packages/ui/src";
 
+@custom-variant dark (&:is(.dark *));
+
 :root {
 	--radius: 0.625rem;
-	--background: oklch(0.985 0.004 255);
+	--background: oklch(1 0 0);
 	--foreground: oklch(0.145 0 0);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.145 0 0);
@@ -19,6 +21,7 @@
 	--accent-foreground: oklch(0.24 0.04 255);
 	--destructive: oklch(0.577 0.245 27.325);
 	--destructive-foreground: oklch(0.985 0 0);
+
 	--success: oklch(0.72 0.14 154);
 	--success-foreground: oklch(0.2 0.03 154);
 	--success-soft: oklch(0.96 0.03 154);
@@ -28,11 +31,10 @@
 	--info: oklch(0.68 0.12 240);
 	--info-foreground: oklch(0.24 0.03 240);
 	--info-soft: oklch(0.96 0.02 240);
+
 	--border: oklch(0.9 0.015 255);
 	--input: oklch(0.922 0 0);
 	--ring: oklch(0.708 0 0);
-	font-family:
-		Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 @theme inline {
@@ -40,6 +42,7 @@
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
+
 	--color-background: var(--background);
 	--color-foreground: var(--foreground);
 	--color-card: var(--card);
@@ -70,70 +73,306 @@
 	--color-ring: var(--ring);
 }
 
-body {
-	margin: 0;
-	min-height: 100vh;
-	background: var(--color-background);
-	color: var(--color-foreground);
+@layer base {
+	* {
+		@apply border-border outline-ring/50;
+	}
+
+	::selection {
+		@apply bg-primary text-primary-foreground;
+	}
+
+	html {
+		font-family:
+			Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	}
+
+	body {
+		@apply bg-background text-foreground;
+		margin: 0;
+		min-height: 100vh;
+	}
+
+	a {
+		@apply text-inherit;
+	}
+
+	button,
+	input,
+	select,
+	textarea {
+		font: inherit;
+	}
+
+	:focus-visible {
+		@apply outline-ring ring-ring/50 ring-3 outline-none;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: clamp(1.875rem, 4vw, 2.6rem);
+		line-height: 1.05;
+		letter-spacing: -0.025em;
+	}
+
+	h2 {
+		margin: 0;
+		font-size: clamp(1.2rem, 2vw, 1.5rem);
+		line-height: 1.2;
+		letter-spacing: -0.02em;
+	}
+
+	h3 {
+		margin: 0;
+		font-size: 1rem;
+		line-height: 1.35;
+		font-weight: 600;
+	}
+
+	p {
+		margin: 0;
+		line-height: 1.65;
+	}
+
+	ul {
+		margin: 0;
+		list-style: disc;
+		padding-inline-start: 1.25rem;
+	}
+	ol {
+		margin: 0;
+		list-style: decimal;
+		padding-inline-start: 1.25rem;
+	}
+
+	li {
+		line-height: 1.6;
+	}
+
+	dl,
+	dt,
+	dd {
+		margin: 0;
+	}
 }
 
-a {
-	color: inherit;
+@layer components {
+	:root {
+		--layout-width: 48rem;
+	}
+
+	.app-shell {
+		@apply min-h-screen bg-background text-foreground antialiased;
+		display: grid;
+		grid-template-rows: auto 1fr auto;
+	}
+
+	.skip-link {
+		@apply bg-background text-foreground border-border fixed start-4 top-4 z-[100] rounded-xl border px-4 py-3 font-medium shadow-sm no-underline;
+		transform: translateY(-140%);
+		transition: transform 0.16s ease;
+	}
+
+	.skip-link:focus-visible {
+		transform: translateY(0);
+	}
+
+	.site-header {
+		@apply border-border/80 bg-background/90 supports-[backdrop-filter]:bg-background/80 border-b text-start backdrop-blur;
+		padding-block: 1rem 1.125rem;
+	}
+
+	.site-width {
+		width: min(100% - 2rem, var(--layout-width));
+		margin: 0 auto;
+	}
+
+	.site-header-inner {
+		@apply flex flex-wrap items-center gap-4 justify-between;
+	}
+
+	.brand {
+		@apply inline-flex min-h-11 flex-col items-start justify-center gap-0.5 no-underline;
+	}
+
+	.brand-mark {
+		@apply text-foreground text-lg font-semibold tracking-tight;
+		line-height: 1.1;
+	}
+
+	.brand-tagline {
+		@apply text-muted-foreground text-xs leading-5;
+		text-wrap: pretty;
+	}
+
+	.site-header-actions {
+		@apply flex flex-wrap items-center gap-2;
+	}
+
+	.site-nav {
+		@apply min-w-0;
+	}
+
+	.site-nav-list {
+		@apply m-0 flex flex-wrap items-center gap-1 list-none p-0;
+	}
+
+	.site-nav-link {
+		@apply text-muted-foreground hover:text-foreground hover:bg-accent focus-visible:border-ring focus-visible:ring-ring/50 inline-flex min-h-9 items-center justify-center rounded-lg px-3 text-sm font-medium no-underline transition-colors focus-visible:ring-3 whitespace-nowrap;
+	}
+
+	.site-nav-link[aria-current="page"] {
+		@apply bg-accent text-accent-foreground;
+	}
+
+	.site-footer {
+		@apply border-border/80 bg-muted/40 border-t text-muted-foreground text-sm;
+		padding-block: 1.25rem 1.5rem;
+	}
+
+	.site-footer-inner {
+		@apply flex flex-wrap items-center justify-between gap-2;
+	}
+
+	.page-title {
+		@apply max-w-[36ch] text-balance text-[clamp(1.75rem,3vw,2.4rem)] font-semibold tracking-tight;
+	}
+
+	.section-title {
+		@apply text-balance text-lg font-semibold tracking-tight md:text-xl;
+	}
+
+	.eyebrow {
+		@apply text-muted-foreground m-0 text-xs font-semibold tracking-[0.08em] uppercase;
+	}
+
+	.supporting-text {
+		@apply text-muted-foreground text-sm leading-6 md:text-[0.95rem];
+	}
+
+	.lead-text {
+		@apply max-w-[65ch] text-base leading-7 md:text-lg;
+	}
+
+	.app-card {
+		@apply bg-card text-card-foreground border-border rounded-2xl border p-6 shadow-sm md:p-8;
+	}
+
+	.panel {
+		@apply bg-card text-card-foreground border-border rounded-2xl border p-5 shadow-sm md:p-6;
+	}
+
+	.panel-subtle {
+		@apply bg-muted/60 text-foreground rounded-2xl border border-transparent p-5 md:p-6;
+	}
+
+	.section-block {
+		@apply grid gap-3;
+	}
+
+	.form-field {
+		@apply grid gap-2;
+	}
+
+	.form-label {
+		@apply text-sm font-semibold tracking-tight;
+	}
+
+	.form-description {
+		@apply text-muted-foreground max-w-[65ch] text-sm leading-6;
+	}
+
+	.app-input {
+		@apply border-input bg-background text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive min-h-11 w-full rounded-xl border px-3.5 py-2.5 shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-3 aria-invalid:ring-3;
+	}
+
+	.summary-grid {
+		@apply grid gap-3 md:grid-cols-2;
+	}
+
+	.summary-item {
+		@apply grid gap-1 rounded-xl border border-border/70 bg-background/75 p-4;
+	}
+
+	.summary-label {
+		@apply text-muted-foreground text-xs font-semibold tracking-[0.04em] uppercase;
+	}
+
+	.summary-value {
+		@apply text-sm font-medium leading-6;
+	}
+
+	.check-list {
+		@apply grid gap-3;
+	}
+
+	.check-row {
+		@apply border-border bg-background/75 grid gap-3 rounded-xl border p-4 md:grid-cols-[auto_minmax(0,1fr)] md:items-start;
+	}
+
+	.error-summary {
+		@apply bg-destructive/10 rounded-2xl border p-4;
+		border-color: var(--color-destructive);
+		border-inline-start-width: 6px;
+	}
+
+	.error-summary-title {
+		@apply text-base font-semibold;
+	}
+
+	.error-text {
+		@apply text-destructive text-sm font-medium;
+	}
+
+	.status-pill {
+		@apply inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-tight;
+	}
+
+	.status-pill[data-tone="success"] {
+		background: var(--color-success-soft);
+		color: var(--color-success-foreground);
+		border-color: color-mix(in oklab, var(--color-success) 30%, transparent);
+	}
+
+	.status-pill[data-tone="info"] {
+		background: var(--color-info-soft);
+		color: var(--color-info-foreground);
+		border-color: color-mix(in oklab, var(--color-info) 30%, transparent);
+	}
+
+	.status-pill[data-tone="warning"] {
+		background: var(--color-warning-soft);
+		color: var(--color-warning-foreground);
+		border-color: color-mix(in oklab, var(--color-warning) 30%, transparent);
+	}
 }
 
-button,
-input,
-select,
-textarea {
-	font: inherit;
-}
+@layer utilities {
+	.stack {
+		@apply grid gap-4;
+	}
 
-.shell {
-	min-height: 100vh;
-	display: grid;
-	place-items: center;
-	padding: 2rem;
-}
+	.stack-sm {
+		@apply grid gap-2;
+	}
 
-.card {
-	width: min(100%, 42rem);
-	border: 1px solid var(--color-border);
-	border-radius: 1.25rem;
-	background: var(--color-card);
-	color: var(--color-card-foreground);
-	padding: 2rem;
-	box-shadow: 0 20px 45px rgb(15 23 42 / 0.08);
-}
+	.stack-lg {
+		@apply grid gap-6;
+	}
 
-.eyebrow {
-	margin: 0 0 0.5rem;
-	color: var(--color-primary);
-	font-weight: 700;
-	text-transform: uppercase;
-	letter-spacing: 0.08em;
-	font-size: 0.75rem;
-}
+	.actions {
+		@apply flex flex-wrap items-center gap-3;
+	}
 
-.stack {
-	display: grid;
-	gap: 1rem;
-}
+	.hint {
+		@apply text-muted-foreground text-sm leading-6;
+	}
 
-.actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 0.75rem;
-	align-items: center;
-}
+	.text-balance {
+		text-wrap: balance;
+	}
 
-.hint {
-	color: var(--color-muted-foreground);
-	font-size: 0.875rem;
-	line-height: 1.5;
-}
-
-[role="alert"],
-.error-text {
-	color: var(--color-destructive);
-	font-weight: 600;
+	.text-pretty {
+		text-wrap: pretty;
+	}
 }

--- a/apps/org-portal/src/routes/+error.svelte
+++ b/apps/org-portal/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { page } from '$app/state'
 import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent } from '@primer-paso/ui/card'
+import { page } from '$app/state'
 
 const status = $derived(page.status)
 const message = $derived(page.error?.message ?? 'Something went wrong.')

--- a/apps/org-portal/src/routes/+error.svelte
+++ b/apps/org-portal/src/routes/+error.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+import { page } from '$app/state'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+
+const status = $derived(page.status)
+const message = $derived(page.error?.message ?? 'Something went wrong.')
+</script>
+
+<svelte:head> <title>{status} | Primer Paso organisation portal</title> </svelte:head>
+
+<div class="stack-lg">
+	<Card class="text-center">
+		<CardHeader class="items-center">
+			<p class="eyebrow">Error {status}</p>
+			<CardTitle class="page-title text-center">
+				{#if status === 404}
+					Page not found
+				{:else if status === 403}
+					Not authorised
+				{:else}
+					Something went wrong
+				{/if}
+			</CardTitle>
+			<CardDescription class="text-pretty">{message}</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<div class="actions justify-center">
+				<Button href="/dashboard">Go to dashboard</Button>
+				<Button href="/" variant="ghost">Back to start</Button>
+			</div>
+		</CardContent>
+	</Card>
+</div>

--- a/apps/org-portal/src/routes/+error.svelte
+++ b/apps/org-portal/src/routes/+error.svelte
@@ -4,10 +4,12 @@ import { Card, CardContent } from '@primer-paso/ui/card'
 import { page } from '$app/state'
 
 const status = $derived(page.status)
-const message = $derived(page.error?.message ?? 'Something went wrong.')
+const message = $derived(page.error?.message ?? 'Algo ha salido mal.')
 </script>
 
-<svelte:head> <title>{status} | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head>
+	<title>{status} | Portal de organizaciones de Primer Paso</title>
+</svelte:head>
 
 <div class="stack-lg">
 	<Card>
@@ -15,17 +17,17 @@ const message = $derived(page.error?.message ?? 'Something went wrong.')
 			<p class="eyebrow">Error {status}</p>
 			<h1 class="text-balance text-[clamp(1.5rem,2.5vw,2rem)] font-semibold tracking-tight">
 				{#if status === 404}
-					Page not found
+					Página no encontrada
 				{:else if status === 403}
-					Not authorised
+					Sin autorización
 				{:else}
-					Something went wrong
+					Algo ha salido mal
 				{/if}
 			</h1>
 			<p class="supporting-text text-pretty">{message}</p>
 			<div class="actions justify-center pt-2">
-				<Button href="/dashboard">Go to dashboard</Button>
-				<Button href="/" variant="ghost">Back to start</Button>
+				<Button href="/dashboard">Ir al panel</Button>
+				<Button href="/" variant="ghost">Volver al inicio</Button>
 			</div>
 		</CardContent>
 	</Card>

--- a/apps/org-portal/src/routes/+error.svelte
+++ b/apps/org-portal/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { page } from '$app/state'
 import { Button } from '@primer-paso/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Card, CardContent } from '@primer-paso/ui/card'
 
 const status = $derived(page.status)
 const message = $derived(page.error?.message ?? 'Something went wrong.')
@@ -10,10 +10,10 @@ const message = $derived(page.error?.message ?? 'Something went wrong.')
 <svelte:head> <title>{status} | Primer Paso organisation portal</title> </svelte:head>
 
 <div class="stack-lg">
-	<Card class="text-center">
-		<CardHeader class="items-center">
+	<Card>
+		<CardContent class="grid gap-3 justify-items-center text-center py-4">
 			<p class="eyebrow">Error {status}</p>
-			<CardTitle class="page-title text-center">
+			<h1 class="text-balance text-[clamp(1.5rem,2.5vw,2rem)] font-semibold tracking-tight">
 				{#if status === 404}
 					Page not found
 				{:else if status === 403}
@@ -21,11 +21,9 @@ const message = $derived(page.error?.message ?? 'Something went wrong.')
 				{:else}
 					Something went wrong
 				{/if}
-			</CardTitle>
-			<CardDescription class="text-pretty">{message}</CardDescription>
-		</CardHeader>
-		<CardContent>
-			<div class="actions justify-center">
+			</h1>
+			<p class="supporting-text text-pretty">{message}</p>
+			<div class="actions justify-center pt-2">
 				<Button href="/dashboard">Go to dashboard</Button>
 				<Button href="/" variant="ghost">Back to start</Button>
 			</div>

--- a/apps/org-portal/src/routes/+error.svelte
+++ b/apps/org-portal/src/routes/+error.svelte
@@ -7,9 +7,7 @@ const status = $derived(page.status)
 const message = $derived(page.error?.message ?? 'Algo ha salido mal.')
 </script>
 
-<svelte:head>
-	<title>{status} | Portal de organizaciones de Primer Paso</title>
-</svelte:head>
+<svelte:head> <title>{status} | Portal de organizaciones de Primer Paso</title> </svelte:head>
 
 <div class="stack-lg">
 	<Card>

--- a/apps/org-portal/src/routes/+layout.server.ts
+++ b/apps/org-portal/src/routes/+layout.server.ts
@@ -1,0 +1,14 @@
+import type { LayoutServerLoad } from './$types'
+
+export const load: LayoutServerLoad = ({ locals }) => {
+	const session = locals.session
+	return {
+		session: session
+			? {
+					email: session.email,
+					role: session.role,
+					permissions: session.permissions
+				}
+			: null
+	}
+}

--- a/apps/org-portal/src/routes/+layout.svelte
+++ b/apps/org-portal/src/routes/+layout.svelte
@@ -5,6 +5,7 @@ import '../app.css'
 let { children, data } = $props()
 
 const session = $derived(data.session)
+const path = $derived(page.url.pathname)
 
 const navItems = $derived(
 	session
@@ -17,13 +18,13 @@ const navItems = $derived(
 					? [{ href: '/admin/audit', label: 'Audit log' }]
 					: [])
 			]
-		: []
+		: [
+				{ href: '/', label: 'Home' },
+				{ href: '/login', label: 'Sign in' }
+			]
 )
 
-const isCurrent = (href: string) => {
-	const path = page.url.pathname
-	return path === href || path.startsWith(`${href}/`)
-}
+const isCurrent = (href: string) => path === href || path.startsWith(`${href}/`)
 </script>
 
 <svelte:head> <meta name="robots" content="noindex, nofollow"> </svelte:head>
@@ -38,23 +39,23 @@ const isCurrent = (href: string) => {
 				<span class="brand-tagline">Organisation portal</span>
 			</a>
 
-			{#if session}
-				<nav class="site-nav" aria-label="Portal navigation">
-					<ul class="site-nav-list">
-						{#each navItems as item (item.href)}
-							<li>
-								<a
-									class="site-nav-link"
-									href={item.href}
-									aria-current={isCurrent(item.href) ? 'page' : undefined}
-								>
-									{item.label}
-								</a>
-							</li>
-						{/each}
-					</ul>
-				</nav>
+			<nav class="site-nav" aria-label="Portal navigation">
+				<ul class="site-nav-list">
+					{#each navItems as item (item.href)}
+						<li>
+							<a
+								class="site-nav-link"
+								href={item.href}
+								aria-current={isCurrent(item.href) ? 'page' : undefined}
+							>
+								{item.label}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</nav>
 
+			{#if session}
 				<div class="site-header-actions">
 					<span class="hint hidden md:inline">{session.email}</span>
 					<form method="POST" action="/logout">

--- a/apps/org-portal/src/routes/+layout.svelte
+++ b/apps/org-portal/src/routes/+layout.svelte
@@ -1,6 +1,76 @@
 <script lang="ts">
+import { page } from '$app/state'
 import '../app.css'
-let { children } = $props()
+
+let { children, data } = $props()
+
+const session = $derived(data.session)
+
+const navItems = $derived(
+	session
+		? [
+				{ href: '/dashboard', label: 'Dashboard' },
+				...(session.permissions.includes('organisation:manage_members')
+					? [{ href: '/admin/members', label: 'Members' }]
+					: []),
+				...(session.permissions.includes('audit:read')
+					? [{ href: '/admin/audit', label: 'Audit log' }]
+					: [])
+			]
+		: []
+)
+
+const isCurrent = (href: string) => {
+	const path = page.url.pathname
+	return path === href || path.startsWith(`${href}/`)
+}
 </script>
 
-{@render children()}
+<svelte:head> <meta name="robots" content="noindex, nofollow"> </svelte:head>
+
+<div class="app-shell">
+	<a class="skip-link" href="#main-content">Skip to main content</a>
+
+	<header class="site-header">
+		<div class="site-header-inner site-width">
+			<a class="brand" href={session ? '/dashboard' : '/'}>
+				<span class="brand-mark">Primer Paso</span>
+				<span class="brand-tagline">Organisation portal</span>
+			</a>
+
+			{#if session}
+				<nav class="site-nav" aria-label="Portal navigation">
+					<ul class="site-nav-list">
+						{#each navItems as item (item.href)}
+							<li>
+								<a
+									class="site-nav-link"
+									href={item.href}
+									aria-current={isCurrent(item.href) ? 'page' : undefined}
+								>
+									{item.label}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</nav>
+
+				<div class="site-header-actions">
+					<span class="hint hidden md:inline">{session.email}</span>
+					<form method="POST" action="/logout">
+						<button class="site-nav-link" type="submit">Sign out</button>
+					</form>
+				</div>
+			{/if}
+		</div>
+	</header>
+
+	<main id="main-content" class="site-width py-8 pb-16">{@render children()}</main>
+
+	<footer class="site-footer">
+		<div class="site-footer-inner site-width">
+			<span>© Primer Paso</span>
+			<span>Authorised users only · Activity is logged</span>
+		</div>
+	</footer>
+</div>

--- a/apps/org-portal/src/routes/+layout.svelte
+++ b/apps/org-portal/src/routes/+layout.svelte
@@ -10,17 +10,17 @@ const path = $derived(page.url.pathname)
 const navItems = $derived(
 	session
 		? [
-				{ href: '/dashboard', label: 'Dashboard' },
+				{ href: '/dashboard', label: 'Panel' },
 				...(session.permissions.includes('organisation:manage_members')
-					? [{ href: '/admin/members', label: 'Members' }]
+					? [{ href: '/admin/members', label: 'Miembros' }]
 					: []),
 				...(session.permissions.includes('audit:read')
-					? [{ href: '/admin/audit', label: 'Audit log' }]
+					? [{ href: '/admin/audit', label: 'Auditoría' }]
 					: [])
 			]
 		: [
-				{ href: '/', label: 'Home' },
-				{ href: '/login', label: 'Sign in' }
+				{ href: '/', label: 'Inicio' },
+				{ href: '/login', label: 'Iniciar sesión' }
 			]
 )
 
@@ -30,16 +30,16 @@ const isCurrent = (href: string) => path === href || path.startsWith(`${href}/`)
 <svelte:head> <meta name="robots" content="noindex, nofollow"> </svelte:head>
 
 <div class="app-shell">
-	<a class="skip-link" href="#main-content">Skip to main content</a>
+	<a class="skip-link" href="#main-content">Saltar al contenido principal</a>
 
 	<header class="site-header">
 		<div class="site-header-inner site-width">
 			<a class="brand" href={session ? '/dashboard' : '/'}>
 				<span class="brand-mark">Primer Paso</span>
-				<span class="brand-tagline">Organisation portal</span>
+				<span class="brand-tagline">Portal de organizaciones</span>
 			</a>
 
-			<nav class="site-nav" aria-label="Portal navigation">
+			<nav class="site-nav" aria-label="Navegación del portal">
 				<ul class="site-nav-list">
 					{#each navItems as item (item.href)}
 						<li>
@@ -59,7 +59,7 @@ const isCurrent = (href: string) => path === href || path.startsWith(`${href}/`)
 				<div class="site-header-actions">
 					<span class="hint hidden md:inline">{session.email}</span>
 					<form method="POST" action="/logout">
-						<button class="site-nav-link" type="submit">Sign out</button>
+						<button class="site-nav-link" type="submit">Cerrar sesión</button>
 					</form>
 				</div>
 			{/if}
@@ -71,7 +71,7 @@ const isCurrent = (href: string) => path === href || path.startsWith(`${href}/`)
 	<footer class="site-footer">
 		<div class="site-footer-inner site-width">
 			<span>© Primer Paso</span>
-			<span>Authorised users only · Activity is logged</span>
+			<span>Solo personas autorizadas · La actividad queda registrada</span>
 		</div>
 	</footer>
 </div>

--- a/apps/org-portal/src/routes/+page.server.ts
+++ b/apps/org-portal/src/routes/+page.server.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit'
+import type { PageServerLoad } from './$types'
+
+export const load: PageServerLoad = ({ locals }) => {
+	if (locals.session) {
+		redirect(303, '/dashboard')
+	}
+}

--- a/apps/org-portal/src/routes/+page.svelte
+++ b/apps/org-portal/src/routes/+page.svelte
@@ -1,20 +1,28 @@
-<svelte:head>
-	<title>Portal de organizaciones | Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<script lang="ts">
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@primer-paso/ui/card'
+</script>
 
-<main class="shell">
-	<section class="card">
+<svelte:head> <title>Organisation portal | Primer Paso</title> </svelte:head>
+
+<div class="stack-lg">
+	<div class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1>Portal de organizaciones</h1>
-		<p>
-			Utiliza este portal para abrir borradores de certificado, revisar la información, registrar
-			las confirmaciones de verificación y preparar certificados para su emisión.
+		<h1 class="page-title">Organisation portal</h1>
+		<p class="lead-text">
+			Open certificate handoffs, review draft information, record verification confirmations, and
+			prepare certificates for issue.
 		</p>
-		<p>
-			La emisión de certificados está limitada a personas autorizadas de la organización y queda
-			registrada en el historial de auditoría.
-		</p>
-		<p><a href="/login">Iniciar sesión</a></p>
-	</section>
-</main>
+	</div>
+
+	<Card>
+		<CardHeader> <CardTitle>Sign in to continue</CardTitle> </CardHeader>
+		<CardContent class="stack">
+			<p class="supporting-text">
+				Certificate issue is limited to authorised organisation users. All actions are recorded in
+				the audit history.
+			</p>
+			<div class="actions"><Button href="/login">Sign in</Button></div>
+		</CardContent>
+	</Card>
+</div>

--- a/apps/org-portal/src/routes/+page.svelte
+++ b/apps/org-portal/src/routes/+page.svelte
@@ -3,26 +3,26 @@ import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@primer-paso/ui/card'
 </script>
 
-<svelte:head> <title>Organisation portal | Primer Paso</title> </svelte:head>
+<svelte:head> <title>Portal de organizaciones | Primer Paso</title> </svelte:head>
 
 <div class="stack-lg">
 	<div class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1 class="page-title">Organisation portal</h1>
+		<h1 class="page-title">Portal de organizaciones</h1>
 		<p class="lead-text">
-			Open certificate handoffs, review draft information, record verification confirmations, and
-			prepare certificates for issue.
+			Utiliza este portal para abrir borradores de certificado, revisar la información, registrar
+			las confirmaciones de verificación y preparar certificados para su emisión.
 		</p>
 	</div>
 
 	<Card>
-		<CardHeader> <CardTitle>Sign in to continue</CardTitle> </CardHeader>
+		<CardHeader> <CardTitle>Iniciar sesión para continuar</CardTitle> </CardHeader>
 		<CardContent class="stack">
 			<p class="supporting-text">
-				Certificate issue is limited to authorised organisation users. All actions are recorded in
-				the audit history.
+				La emisión de certificados está limitada a personas autorizadas de la organización. Todas
+				las acciones quedan registradas en el historial de auditoría.
 			</p>
-			<div class="actions"><Button href="/login">Sign in</Button></div>
+			<div class="actions"><Button href="/login">Iniciar sesión</Button></div>
 		</CardContent>
 	</Card>
 </div>

--- a/apps/org-portal/src/routes/admin/audit/+page.svelte
+++ b/apps/org-portal/src/routes/admin/audit/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
 import { Badge } from '@primer-paso/ui/badge'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import {
 	Table,
 	TableBody,
@@ -20,55 +23,73 @@ const formatDate = (value: string) =>
 	}).format(new Date(value))
 </script>
 
-<svelte:head>
-	<title>Registro de auditoría | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<svelte:head> <title>Audit log | Primer Paso organisation portal</title> </svelte:head>
 
-<main class="shell">
-	<section class="card">
-		<p class="eyebrow">Administración de la organización</p>
-		<h1>Registro de auditoría</h1>
-		<p>Últimas acciones registradas para <strong>{data.organisation.name}</strong>.</p>
+<div class="stack-lg">
+	<header class="section-block">
+		<p class="eyebrow">Organisation admin</p>
+		<h1 class="page-title">Audit log</h1>
+		<p class="supporting-text">
+			Latest recorded actions for <strong>{data.organisation.name}</strong>.
+		</p>
+	</header>
 
-		<p>Este historial ayuda a comprobar quién ha accedido, revisado o emitido certificados.</p>
-		<p><a href="/dashboard">Volver al panel de la organización</a></p>
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Back to dashboard
+		</Button>
+	</div>
 
-		{#if data.events.length === 0}
-			<p>Aún no se ha registrado ningún evento de auditoría.</p>
-		{:else}
-			<Table>
-				<TableHeader>
-					<TableRow>
-						<TableHead>Hora</TableHead>
-						<TableHead>Evento</TableHead>
-						<TableHead>Actor</TableHead>
-						<TableHead>Revisión</TableHead>
-						<TableHead>Detalles</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody>
-					{#each data.events as event}
+	<Card>
+		<CardHeader>
+			<CardTitle>Recent events</CardTitle>
+			<CardDescription>
+				{data.events.length}
+				event{data.events.length === 1 ? '' : 's'}
+				recorded.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			{#if data.events.length === 0}
+				<p class="hint">No audit events have been recorded yet.</p>
+			{:else}
+				<Table>
+					<TableHeader>
 						<TableRow>
-							<TableCell>{formatDate(event.createdAt)}</TableCell>
-							<TableCell>
-								<Badge variant="secondary">{auditEventLabel(event.eventType)}</Badge>
-							</TableCell>
-							<TableCell>{event.memberEmail ?? 'Sistema'}</TableCell>
-							<TableCell>
-								{#if event.reviewId}
-									<a href={`/reviews/${event.reviewId}`}>Ver revisión</a>
-								{:else}
-									<span>—</span>
-								{/if}
-							</TableCell>
-							<TableCell class="whitespace-normal"
-								>{formatAuditEventData(event.eventData)}</TableCell
-							>
+							<TableHead>Time</TableHead>
+							<TableHead>Event</TableHead>
+							<TableHead>Actor</TableHead>
+							<TableHead>Review</TableHead>
+							<TableHead>Details</TableHead>
 						</TableRow>
-					{/each}
-				</TableBody>
-			</Table>
-		{/if}
-	</section>
-</main>
+					</TableHeader>
+					<TableBody>
+						{#each data.events as event}
+							<TableRow>
+								<TableCell class="whitespace-nowrap">{formatDate(event.createdAt)}</TableCell>
+								<TableCell> <Badge variant="secondary">{event.eventType}</Badge> </TableCell>
+								<TableCell>{event.memberEmail ?? 'System'}</TableCell>
+								<TableCell>
+									{#if event.reviewId}
+										<a
+											class="text-primary underline-offset-4 hover:underline"
+											href={`/reviews/${event.reviewId}`}
+										>
+											Open review
+										</a>
+									{:else}
+										<span class="text-muted-foreground">—</span>
+									{/if}
+								</TableCell>
+								<TableCell class="whitespace-normal text-muted-foreground">
+									{formatEventData(event.eventData)}
+								</TableCell>
+							</TableRow>
+						{/each}
+					</TableBody>
+				</Table>
+			{/if}
+		</CardContent>
+	</Card>
+</div>

--- a/apps/org-portal/src/routes/admin/audit/+page.svelte
+++ b/apps/org-portal/src/routes/admin/audit/+page.svelte
@@ -23,62 +23,68 @@ const formatDate = (value: string) =>
 	}).format(new Date(value))
 </script>
 
-<svelte:head> <title>Audit log | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head>
+	<title>Registro de auditoría | Portal de organizaciones de Primer Paso</title>
+</svelte:head>
 
 <div class="stack-lg">
 	<header class="section-block">
-		<p class="eyebrow">Organisation admin</p>
-		<h1 class="page-title">Audit log</h1>
+		<p class="eyebrow">Administración de la organización</p>
+		<h1 class="page-title">Registro de auditoría</h1>
 		<p class="supporting-text">
-			Latest recorded actions for <strong>{data.organisation.name}</strong>.
+			Últimas acciones registradas para <strong>{data.organisation.name}</strong>.
 		</p>
 	</header>
 
 	<div class="bleed-wide">
 		<Card>
 			<CardHeader>
-				<CardTitle>Recent events</CardTitle>
+				<CardTitle>Eventos recientes</CardTitle>
 				<CardDescription>
 					{data.events.length}
-					event{data.events.length === 1 ? '' : 's'}
-					recorded.
+					evento{data.events.length === 1 ? '' : 's'}
+					registrado{data.events.length === 1
+						? ''
+						: 's'}.
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
 				{#if data.events.length === 0}
-					<p class="hint">No audit events have been recorded yet.</p>
+					<p class="hint">Aún no se ha registrado ningún evento de auditoría.</p>
 				{:else}
 					<div class="max-h-[60vh] overflow-auto rounded-lg border border-border/60">
 						<Table>
 							<TableHeader class="sticky top-0 bg-muted/80 backdrop-blur z-10">
 								<TableRow>
-									<TableHead>Time</TableHead>
-									<TableHead>Event</TableHead>
+									<TableHead>Hora</TableHead>
+									<TableHead>Evento</TableHead>
 									<TableHead>Actor</TableHead>
-									<TableHead>Review</TableHead>
-									<TableHead>Details</TableHead>
+									<TableHead>Revisión</TableHead>
+									<TableHead>Detalles</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
 								{#each data.events as event}
 									<TableRow>
 										<TableCell class="whitespace-nowrap">{formatDate(event.createdAt)}</TableCell>
-										<TableCell> <Badge variant="secondary">{event.eventType}</Badge> </TableCell>
-										<TableCell>{event.memberEmail ?? 'System'}</TableCell>
+										<TableCell>
+											<Badge variant="secondary">{auditEventLabel(event.eventType)}</Badge>
+										</TableCell>
+										<TableCell>{event.memberEmail ?? 'Sistema'}</TableCell>
 										<TableCell>
 											{#if event.reviewId}
 												<a
 													class="text-primary underline-offset-4 hover:underline"
 													href={`/reviews/${event.reviewId}`}
 												>
-													Open review
+													Ver revisión
 												</a>
 											{:else}
 												<span class="text-muted-foreground">—</span>
 											{/if}
 										</TableCell>
 										<TableCell class="whitespace-normal text-muted-foreground">
-											{formatEventData(event.eventData)}
+											{formatAuditEventData(event.eventData)}
 										</TableCell>
 									</TableRow>
 								{/each}
@@ -93,7 +99,7 @@ const formatDate = (value: string) =>
 	<div class="actions">
 		<Button href="/dashboard" variant="ghost">
 			<ArrowLeftIcon class="size-4" aria-hidden="true" />
-			Back to dashboard
+			Volver al panel
 		</Button>
 	</div>
 </div>

--- a/apps/org-portal/src/routes/admin/audit/+page.svelte
+++ b/apps/org-portal/src/routes/admin/audit/+page.svelte
@@ -34,62 +34,66 @@ const formatDate = (value: string) =>
 		</p>
 	</header>
 
+	<div class="bleed-wide">
+		<Card>
+			<CardHeader>
+				<CardTitle>Recent events</CardTitle>
+				<CardDescription>
+					{data.events.length}
+					event{data.events.length === 1 ? '' : 's'}
+					recorded.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{#if data.events.length === 0}
+					<p class="hint">No audit events have been recorded yet.</p>
+				{:else}
+					<div class="max-h-[60vh] overflow-auto rounded-lg border border-border/60">
+						<Table>
+							<TableHeader class="sticky top-0 bg-muted/80 backdrop-blur z-10">
+								<TableRow>
+									<TableHead>Time</TableHead>
+									<TableHead>Event</TableHead>
+									<TableHead>Actor</TableHead>
+									<TableHead>Review</TableHead>
+									<TableHead>Details</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{#each data.events as event}
+									<TableRow>
+										<TableCell class="whitespace-nowrap">{formatDate(event.createdAt)}</TableCell>
+										<TableCell> <Badge variant="secondary">{event.eventType}</Badge> </TableCell>
+										<TableCell>{event.memberEmail ?? 'System'}</TableCell>
+										<TableCell>
+											{#if event.reviewId}
+												<a
+													class="text-primary underline-offset-4 hover:underline"
+													href={`/reviews/${event.reviewId}`}
+												>
+													Open review
+												</a>
+											{:else}
+												<span class="text-muted-foreground">—</span>
+											{/if}
+										</TableCell>
+										<TableCell class="whitespace-normal text-muted-foreground">
+											{formatEventData(event.eventData)}
+										</TableCell>
+									</TableRow>
+								{/each}
+							</TableBody>
+						</Table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
+	</div>
+
 	<div class="actions">
 		<Button href="/dashboard" variant="ghost">
 			<ArrowLeftIcon class="size-4" aria-hidden="true" />
 			Back to dashboard
 		</Button>
 	</div>
-
-	<Card>
-		<CardHeader>
-			<CardTitle>Recent events</CardTitle>
-			<CardDescription>
-				{data.events.length}
-				event{data.events.length === 1 ? '' : 's'}
-				recorded.
-			</CardDescription>
-		</CardHeader>
-		<CardContent>
-			{#if data.events.length === 0}
-				<p class="hint">No audit events have been recorded yet.</p>
-			{:else}
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>Time</TableHead>
-							<TableHead>Event</TableHead>
-							<TableHead>Actor</TableHead>
-							<TableHead>Review</TableHead>
-							<TableHead>Details</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{#each data.events as event}
-							<TableRow>
-								<TableCell class="whitespace-nowrap">{formatDate(event.createdAt)}</TableCell>
-								<TableCell> <Badge variant="secondary">{event.eventType}</Badge> </TableCell>
-								<TableCell>{event.memberEmail ?? 'System'}</TableCell>
-								<TableCell>
-									{#if event.reviewId}
-										<a
-											class="text-primary underline-offset-4 hover:underline"
-											href={`/reviews/${event.reviewId}`}
-										>
-											Open review
-										</a>
-									{:else}
-										<span class="text-muted-foreground">—</span>
-									{/if}
-								</TableCell>
-								<TableCell class="whitespace-normal text-muted-foreground">
-									{formatEventData(event.eventData)}
-								</TableCell>
-							</TableRow>
-						{/each}
-					</TableBody>
-				</Table>
-			{/if}
-		</CardContent>
-	</Card>
 </div>

--- a/apps/org-portal/src/routes/admin/members/+page.svelte
+++ b/apps/org-portal/src/routes/admin/members/+page.svelte
@@ -33,37 +33,38 @@ const activeMembers = $derived(data.members.filter((member) => member.status ===
 const inactiveMembers = $derived(data.members.filter((member) => member.status !== 'active'))
 </script>
 
-<svelte:head> <title>Members | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head> <title>Miembros | Portal de organizaciones de Primer Paso</title> </svelte:head>
 
 <div class="stack-lg">
 	<header class="section-block">
-		<p class="eyebrow">Organisation admin</p>
-		<h1 class="page-title">Members</h1>
+		<p class="eyebrow">Administración de la organización</p>
+		<h1 class="page-title">Miembros</h1>
 		<p class="supporting-text">
-			Manage who can use the organisation portal for <strong>{data.organisation.name}</strong>.
+			Gestiona quién puede usar el portal de organizaciones de
+			<strong>{data.organisation.name}</strong>.
 		</p>
 	</header>
 
 	{#if form?.error}
 		<div class="error-summary" role="alert">
-			<p class="error-summary-title">Could not save changes</p>
+			<p class="error-summary-title">No se pudieron guardar los cambios</p>
 			<p class="error-text">{form.error}</p>
 		</div>
 	{/if}
 
 	<Card>
 		<CardHeader>
-			<CardTitle id="add-member-title">Add or reactivate a member</CardTitle>
+			<CardTitle id="add-member-title">Añadir o reactivar un miembro</CardTitle>
 			<CardDescription>
-				This uses the current pilot login mechanism. A member can sign in with their email and the
-				shared organisation access code until email delivery replaces it.
+				Añade aquí a las personas autorizadas de la organización. Podrán iniciar sesión con su
+				correo electrónico mediante un enlace de acceso seguro.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
 			<form method="POST" action="?/add" class="stack" aria-labelledby="add-member-title">
 				<div class="grid gap-4 md:grid-cols-3">
 					<div class="form-field">
-						<Label for="name">Name</Label>
+						<Label for="name">Nombre</Label>
 						<Input
 							id="name"
 							name="name"
@@ -73,7 +74,7 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 						/>
 					</div>
 					<div class="form-field">
-						<Label for="email">Email</Label>
+						<Label for="email">Correo electrónico</Label>
 						<Input
 							id="email"
 							name="email"
@@ -84,7 +85,7 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 						/>
 					</div>
 					<div class="form-field">
-						<Label for="role">Role</Label>
+						<Label for="role">Rol</Label>
 						<NativeSelect id="role" name="role" required>
 							{#each data.roles as role}
 								<NativeSelectOption
@@ -99,17 +100,20 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 						</NativeSelect>
 					</div>
 				</div>
-				<div class="actions"><Button type="submit">Save member</Button></div>
+				<div class="actions"><Button type="submit">Guardar miembro</Button></div>
 			</form>
 		</CardContent>
 	</Card>
 
 	<Card>
 		<CardHeader>
-			<CardTitle id="active-members-title">Active members</CardTitle>
+			<CardTitle id="active-members-title">Miembros activos</CardTitle>
 			<CardDescription>
 				{activeMembers.length}
-				active member{activeMembers.length === 1 ? '' : 's'}.
+				miembro{activeMembers.length === 1 ? '' : 's'}
+				activo{activeMembers.length === 1
+					? ''
+					: 's'}.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
@@ -171,10 +175,13 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 	{#if inactiveMembers.length > 0}
 		<Card>
 			<CardHeader>
-				<CardTitle id="inactive-members-title">Inactive members</CardTitle>
+				<CardTitle id="inactive-members-title">Miembros inactivos</CardTitle>
 				<CardDescription>
 					{inactiveMembers.length}
-					inactive member{inactiveMembers.length === 1 ? '' : 's'}.
+					miembro{inactiveMembers.length === 1 ? '' : 's'}
+					inactivo{inactiveMembers.length === 1
+						? ''
+						: 's'}.
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
@@ -214,7 +221,7 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 	<div class="actions">
 		<Button href="/dashboard" variant="ghost">
 			<ArrowLeftIcon class="size-4" aria-hidden="true" />
-			Back to dashboard
+			Volver al panel
 		</Button>
 	</div>
 </div>

--- a/apps/org-portal/src/routes/admin/members/+page.svelte
+++ b/apps/org-portal/src/routes/admin/members/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
-import HistoryIcon from '@lucide/svelte/icons/history'
 import { Badge } from '@primer-paso/ui/badge'
 import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
@@ -44,17 +43,6 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 			Manage who can use the organisation portal for <strong>{data.organisation.name}</strong>.
 		</p>
 	</header>
-
-	<div class="actions">
-		<Button href="/dashboard" variant="ghost">
-			<ArrowLeftIcon class="size-4" aria-hidden="true" />
-			Back to dashboard
-		</Button>
-		<Button href="/admin/audit" variant="ghost">
-			<HistoryIcon class="size-4" aria-hidden="true" />
-			View audit log
-		</Button>
-	</div>
 
 	{#if form?.error}
 		<div class="error-summary" role="alert">
@@ -222,4 +210,11 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 			</CardContent>
 		</Card>
 	{/if}
+
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Back to dashboard
+		</Button>
+	</div>
 </div>

--- a/apps/org-portal/src/routes/admin/members/+page.svelte
+++ b/apps/org-portal/src/routes/admin/members/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
+import HistoryIcon from '@lucide/svelte/icons/history'
 import { Badge } from '@primer-paso/ui/badge'
 import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import { Input } from '@primer-paso/ui/input'
 import { Label } from '@primer-paso/ui/label'
 import { NativeSelect, NativeSelectOption } from '@primer-paso/ui/native-select'
@@ -31,84 +34,97 @@ const activeMembers = $derived(data.members.filter((member) => member.status ===
 const inactiveMembers = $derived(data.members.filter((member) => member.status !== 'active'))
 </script>
 
-<svelte:head>
-	<title>Miembros | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<svelte:head> <title>Members | Primer Paso organisation portal</title> </svelte:head>
 
-<main class="shell">
-	<section class="card">
-		<p class="eyebrow">Administración de la organización</p>
-		<h1>Miembros</h1>
-		<p>
-			Gestiona quién puede usar el portal de organizaciones de
-			<strong>{data.organisation.name}</strong>.
+<div class="stack-lg">
+	<header class="section-block">
+		<p class="eyebrow">Organisation admin</p>
+		<h1 class="page-title">Members</h1>
+		<p class="supporting-text">
+			Manage who can use the organisation portal for <strong>{data.organisation.name}</strong>.
 		</p>
+	</header>
 
-		<p>
-			<a href="/dashboard">Volver al panel de la organización</a>
-			{' · '}
-			<a href="/admin/audit">Ver registro de auditoría</a>
-		</p>
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Back to dashboard
+		</Button>
+		<Button href="/admin/audit" variant="ghost">
+			<HistoryIcon class="size-4" aria-hidden="true" />
+			View audit log
+		</Button>
+	</div>
 
-		{#if form?.error}
-			<p role="alert">{form.error}</p>
-		{/if}
+	{#if form?.error}
+		<div class="error-summary" role="alert">
+			<p class="error-summary-title">Could not save changes</p>
+			<p class="error-text">{form.error}</p>
+		</div>
+	{/if}
 
-		<section aria-labelledby="add-member-title">
-			<h2 id="add-member-title">Añadir o reactivar un miembro</h2>
-			<p>
-				Añade aquí a las personas autorizadas de la organización. Podrán iniciar sesión con su
-				correo electrónico mediante un enlace de acceso seguro.
-			</p>
-
-			<form method="POST" action="?/add">
-				<div>
-					<Label for="name">Nombre</Label>
-					<Input
-						id="name"
-						name="name"
-						autocomplete="name"
-						required
-						value={form?.intent === 'add' ? form.value?.name : ''}
-					/>
+	<Card>
+		<CardHeader>
+			<CardTitle id="add-member-title">Add or reactivate a member</CardTitle>
+			<CardDescription>
+				This uses the current pilot login mechanism. A member can sign in with their email and the
+				shared organisation access code until email delivery replaces it.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<form method="POST" action="?/add" class="stack" aria-labelledby="add-member-title">
+				<div class="grid gap-4 md:grid-cols-3">
+					<div class="form-field">
+						<Label for="name">Name</Label>
+						<Input
+							id="name"
+							name="name"
+							autocomplete="name"
+							required
+							value={form?.intent === 'add' ? form.value?.name : ''}
+						/>
+					</div>
+					<div class="form-field">
+						<Label for="email">Email</Label>
+						<Input
+							id="email"
+							name="email"
+							type="email"
+							autocomplete="email"
+							required
+							value={form?.intent === 'add' ? form.value?.email : ''}
+						/>
+					</div>
+					<div class="form-field">
+						<Label for="role">Role</Label>
+						<NativeSelect id="role" name="role" required>
+							{#each data.roles as role}
+								<NativeSelectOption
+									value={role}
+									selected={form?.intent === 'add'
+										? form.value?.role === role
+										: role === 'intake_volunteer'}
+								>
+									{roleLabel(role)}
+								</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
 				</div>
-
-				<div>
-					<Label for="email">Correo electrónico</Label>
-					<Input
-						id="email"
-						name="email"
-						type="email"
-						autocomplete="email"
-						required
-						value={form?.intent === 'add' ? form.value?.email : ''}
-					/>
-				</div>
-
-				<div>
-					<Label for="role">Rol</Label>
-					<NativeSelect id="role" name="role" required>
-						{#each data.roles as role}
-							<NativeSelectOption
-								value={role}
-								selected={form?.intent === 'add'
-									? form.value?.role === role
-									: role === 'intake_volunteer'}
-							>
-								{roleLabel(role)}
-							</NativeSelectOption>
-						{/each}
-					</NativeSelect>
-				</div>
-
-				<p><Button type="submit">Guardar miembro</Button></p>
+				<div class="actions"><Button type="submit">Save member</Button></div>
 			</form>
-		</section>
+		</CardContent>
+	</Card>
 
-		<section aria-labelledby="active-members-title">
-			<h2 id="active-members-title">Miembros activos</h2>
-
+	<Card>
+		<CardHeader>
+			<CardTitle id="active-members-title">Active members</CardTitle>
+			<CardDescription>
+				{activeMembers.length}
+				active member{activeMembers.length === 1 ? '' : 's'}.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
 			<Table>
 				<TableHeader>
 					<TableRow>
@@ -123,8 +139,10 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 					{#each activeMembers as member}
 						<TableRow>
 							<TableCell>
-								<strong>{member.name}</strong><br>
-								<span>{member.email}</span>
+								<div class="grid gap-0.5">
+									<strong>{member.name}</strong>
+									<span class="hint">{member.email}</span>
+								</div>
 							</TableCell>
 							<TableCell>
 								<Badge variant={statusVariant(member.status)}
@@ -132,7 +150,7 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 								>
 							</TableCell>
 							<TableCell>
-								<form method="POST" action="?/role">
+								<form method="POST" action="?/role" class="flex flex-wrap items-center gap-2">
 									<input type="hidden" name="memberId" value={member.id}>
 									<NativeSelect name="role" aria-label={`Rol de ${member.email}`}>
 										{#each data.roles as role}
@@ -144,7 +162,7 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 									<Button type="submit" variant="outline" size="sm">Guardar rol</Button>
 								</form>
 							</TableCell>
-							<TableCell>{formatDate(member.createdAt)}</TableCell>
+							<TableCell class="whitespace-nowrap">{formatDate(member.createdAt)}</TableCell>
 							<TableCell>
 								{#if member.id === data.currentMemberId}
 									<Badge variant="outline">Usuario actual</Badge>
@@ -159,12 +177,19 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 					{/each}
 				</TableBody>
 			</Table>
-		</section>
+		</CardContent>
+	</Card>
 
-		{#if inactiveMembers.length > 0}
-			<section aria-labelledby="inactive-members-title">
-				<h2 id="inactive-members-title">Miembros inactivos</h2>
-
+	{#if inactiveMembers.length > 0}
+		<Card>
+			<CardHeader>
+				<CardTitle id="inactive-members-title">Inactive members</CardTitle>
+				<CardDescription>
+					{inactiveMembers.length}
+					inactive member{inactiveMembers.length === 1 ? '' : 's'}.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
 				<Table>
 					<TableHeader>
 						<TableRow>
@@ -178,8 +203,10 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 						{#each inactiveMembers as member}
 							<TableRow>
 								<TableCell>
-									<strong>{member.name}</strong><br>
-									<span>{member.email}</span>
+									<div class="grid gap-0.5">
+										<strong>{member.name}</strong>
+										<span class="hint">{member.email}</span>
+									</div>
 								</TableCell>
 								<TableCell>
 									<Badge variant={statusVariant(member.status)}
@@ -187,12 +214,12 @@ const inactiveMembers = $derived(data.members.filter((member) => member.status !
 									>
 								</TableCell>
 								<TableCell>{roleLabel(member.role)}</TableCell>
-								<TableCell>{formatDate(member.disabledAt)}</TableCell>
+								<TableCell class="whitespace-nowrap">{formatDate(member.disabledAt)}</TableCell>
 							</TableRow>
 						{/each}
 					</TableBody>
 				</Table>
-			</section>
-		{/if}
-	</section>
-</main>
+			</CardContent>
+		</Card>
+	{/if}
+</div>

--- a/apps/org-portal/src/routes/dashboard/+page.svelte
+++ b/apps/org-portal/src/routes/dashboard/+page.svelte
@@ -7,28 +7,27 @@ import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import { Input } from '@primer-paso/ui/input'
 import { Label } from '@primer-paso/ui/label'
+import { roleLabel } from '$lib/labels'
 
 let { data } = $props()
 </script>
 
-<svelte:head> <title>Dashboard | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head> <title>Panel | Portal de organizaciones de Primer Paso</title> </svelte:head>
 
 <div class="stack-lg">
 	<header class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1 class="page-title">Organisation dashboard</h1>
+		<h1 class="page-title">Panel de la organización</h1>
 		<div class="actions">
-			<span class="hint">Signed in as</span>
-			<Badge variant="secondary">{data.session.role}</Badge>
+			<span class="hint">Sesión iniciada como</span>
+			<Badge variant="secondary">{roleLabel(data.session.role)}</Badge>
 		</div>
 	</header>
 
 	{#if data.permissionError}
 		<div class="error-summary" role="alert">
-			<p class="error-summary-title">Permission denied</p>
-			<p class="error-text">
-				You do not have permission to perform that action for this organisation.
-			</p>
+			<p class="error-summary-title">Permiso denegado</p>
+			<p class="error-text">No tienes permiso para realizar esa acción en esta organización.</p>
 		</div>
 	{/if}
 
@@ -37,20 +36,20 @@ let { data } = $props()
 			<CardTitle>
 				<span class="inline-flex items-center gap-2">
 					<ClipboardListIcon class="size-5 text-muted-foreground" aria-hidden="true" />
-					Open a certificate handoff
+					Abrir un borrador de certificado
 				</span>
 			</CardTitle>
 			<CardDescription>
-				Open this page from a Primer Paso QR code, or paste the handoff link or token below.
+				Escanea un código QR de Primer Paso o pega abajo el enlace o código del borrador.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
 			<form method="GET" action="/handoff" class="stack">
 				<div class="form-field">
-					<Label for="token">Handoff token or link</Label>
-					<Input id="token" name="token" autocomplete="off" placeholder="Paste a token or URL" />
+					<Label for="token">Enlace o código del borrador</Label>
+					<Input id="token" name="token" autocomplete="off" placeholder="Pega un enlace o código" />
 				</div>
-				<div class="actions"><Button type="submit">Open handoff</Button></div>
+				<div class="actions"><Button type="submit">Abrir borrador</Button></div>
 			</form>
 		</CardContent>
 	</Card>
@@ -58,8 +57,8 @@ let { data } = $props()
 	{#if data.adminLinks.canManageMembers || data.adminLinks.canReadAudit}
 		<Card>
 			<CardHeader>
-				<CardTitle>Organisation admin</CardTitle>
-				<CardDescription>Tools available to your role.</CardDescription>
+				<CardTitle>Administración de la organización</CardTitle>
+				<CardDescription>Herramientas disponibles según tu permiso.</CardDescription>
 			</CardHeader>
 			<CardContent>
 				<div class="grid gap-3 md:grid-cols-2">
@@ -70,8 +69,10 @@ let { data } = $props()
 						>
 							<UsersIcon class="size-5 mt-0.5 text-muted-foreground" aria-hidden="true" />
 							<span class="grid gap-1">
-								<span class="section-title">Manage members</span>
-								<span class="hint">Add, deactivate, or change roles for organisation members.</span>
+								<span class="section-title">Gestionar miembros</span>
+								<span class="hint">
+									Añade, desactiva o cambia el rol de los miembros de la organización.
+								</span>
 							</span>
 						</a>
 					{/if}
@@ -82,8 +83,10 @@ let { data } = $props()
 						>
 							<HistoryIcon class="size-5 mt-0.5 text-muted-foreground" aria-hidden="true" />
 							<span class="grid gap-1">
-								<span class="section-title">View audit log</span>
-								<span class="hint">Review actions taken in the portal for this organisation.</span>
+								<span class="section-title">Ver registro de auditoría</span>
+								<span class="hint">
+									Revisa las acciones realizadas en el portal para esta organización.
+								</span>
 							</span>
 						</a>
 					{/if}

--- a/apps/org-portal/src/routes/dashboard/+page.svelte
+++ b/apps/org-portal/src/routes/dashboard/+page.svelte
@@ -1,53 +1,94 @@
 <script lang="ts">
-import { roleLabel } from '$lib/labels'
+import ClipboardListIcon from '@lucide/svelte/icons/clipboard-list'
+import HistoryIcon from '@lucide/svelte/icons/history'
+import UsersIcon from '@lucide/svelte/icons/users'
+import { Badge } from '@primer-paso/ui/badge'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Input } from '@primer-paso/ui/input'
+import { Label } from '@primer-paso/ui/label'
 
 let { data } = $props()
 </script>
 
-<svelte:head>
-	<title>Panel | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<svelte:head> <title>Dashboard | Primer Paso organisation portal</title> </svelte:head>
 
-<main class="shell">
-	<section class="card">
+<div class="stack-lg">
+	<header class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1>Panel de la organización</h1>
+		<h1 class="page-title">Organisation dashboard</h1>
+		<div class="actions">
+			<span class="hint">Signed in as</span>
+			<Badge variant="secondary">{data.session.role}</Badge>
+		</div>
+	</header>
 
-		{#if data.permissionError}
-			<p role="alert">No tienes permiso para realizar esa acción en esta organización.</p>
-		{/if}
+	{#if data.permissionError}
+		<div class="error-summary" role="alert">
+			<p class="error-summary-title">Permission denied</p>
+			<p class="error-text">
+				You do not have permission to perform that action for this organisation.
+			</p>
+		</div>
+	{/if}
 
-		<p>
-			Has iniciado sesión como miembro de la organización con permiso de
-			<strong>{roleLabel(data.session.role)}</strong>.
-		</p>
+	<Card>
+		<CardHeader>
+			<CardTitle>
+				<span class="inline-flex items-center gap-2">
+					<ClipboardListIcon class="size-5 text-muted-foreground" aria-hidden="true" />
+					Open a certificate handoff
+				</span>
+			</CardTitle>
+			<CardDescription>
+				Open this page from a Primer Paso QR code, or paste the handoff link or token below.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<form method="GET" action="/handoff" class="stack">
+				<div class="form-field">
+					<Label for="token">Handoff token or link</Label>
+					<Input id="token" name="token" autocomplete="off" placeholder="Paste a token or URL" />
+				</div>
+				<div class="actions"><Button type="submit">Open handoff</Button></div>
+			</form>
+		</CardContent>
+	</Card>
 
-		<h2>Abrir un borrador recibido</h2>
-		<form method="GET" action="/handoff" class="stack">
-			<label>
-				Enlace o código del borrador
-				<input name="token" autocomplete="off">
-			</label>
-			<button type="submit">Abrir borrador</button>
-		</form>
-
-		<p>Escanea un código QR de Primer Paso o pega arriba el enlace o código del borrador.</p>
-
-		{#if data.adminLinks.canManageMembers || data.adminLinks.canReadAudit}
-			<section>
-				<h2>Administración de la organización</h2>
-				<ul>
+	{#if data.adminLinks.canManageMembers || data.adminLinks.canReadAudit}
+		<Card>
+			<CardHeader>
+				<CardTitle>Organisation admin</CardTitle>
+				<CardDescription>Tools available to your role.</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<div class="grid gap-3 md:grid-cols-2">
 					{#if data.adminLinks.canManageMembers}
-						<li><a href="/admin/members">Gestionar miembros</a></li>
+						<a
+							href="/admin/members"
+							class="panel-subtle flex items-start gap-3 no-underline transition-colors hover:bg-accent/60"
+						>
+							<UsersIcon class="size-5 mt-0.5 text-muted-foreground" aria-hidden="true" />
+							<span class="grid gap-1">
+								<span class="section-title">Manage members</span>
+								<span class="hint">Add, deactivate, or change roles for organisation members.</span>
+							</span>
+						</a>
 					{/if}
 					{#if data.adminLinks.canReadAudit}
-						<li><a href="/admin/audit">Ver registro de auditoría</a></li>
+						<a
+							href="/admin/audit"
+							class="panel-subtle flex items-start gap-3 no-underline transition-colors hover:bg-accent/60"
+						>
+							<HistoryIcon class="size-5 mt-0.5 text-muted-foreground" aria-hidden="true" />
+							<span class="grid gap-1">
+								<span class="section-title">View audit log</span>
+								<span class="hint">Review actions taken in the portal for this organisation.</span>
+							</span>
+						</a>
 					{/if}
-				</ul>
-			</section>
-		{/if}
-
-		<form method="POST" action="/logout"><button type="submit">Cerrar sesión</button></form>
-	</section>
-</main>
+				</div>
+			</CardContent>
+		</Card>
+	{/if}
+</div>

--- a/apps/org-portal/src/routes/handoff/+page.svelte
+++ b/apps/org-portal/src/routes/handoff/+page.svelte
@@ -7,28 +7,30 @@ import { Label } from '@primer-paso/ui/label'
 let { data } = $props()
 </script>
 
-<svelte:head> <title>Certificate handoff | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head>
+	<title>Borrador de certificado | Portal de organizaciones de Primer Paso</title>
+</svelte:head>
 
 <div class="stack-lg">
 	<header class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1 class="page-title">Certificate handoff</h1>
+		<h1 class="page-title">Borrador de certificado</h1>
 	</header>
 
 	<Card>
 		<CardHeader>
 			<CardTitle>
 				{#if data.hasToken}
-					Handoff reference received
+					Referencia de borrador recibida
 				{:else}
-					No handoff reference
+					Sin referencia de borrador
 				{/if}
 			</CardTitle>
 			<CardDescription>
 				{#if data.hasToken}
-					Sign in as an authorised organisation user to open the draft.
+					Inicia sesión como persona autorizada de la organización para abrir el borrador.
 				{:else}
-					Open this page from a Primer Paso certificate handoff QR code or link.
+					Abre esta página desde un código QR de Primer Paso o pega el enlace o código del borrador.
 				{/if}
 			</CardDescription>
 		</CardHeader>
@@ -36,10 +38,15 @@ let { data } = $props()
 			<CardContent>
 				<form method="GET" action="/handoff" class="stack">
 					<div class="form-field">
-						<Label for="token">Handoff token or link</Label>
-						<Input id="token" name="token" autocomplete="off" placeholder="Paste a token or URL" />
+						<Label for="token">Enlace o código del borrador</Label>
+						<Input
+							id="token"
+							name="token"
+							autocomplete="off"
+							placeholder="Pega un enlace o código"
+						/>
 					</div>
-					<div class="actions"><Button type="submit">Open handoff</Button></div>
+					<div class="actions"><Button type="submit">Abrir borrador</Button></div>
 				</form>
 			</CardContent>
 		{/if}

--- a/apps/org-portal/src/routes/handoff/+page.svelte
+++ b/apps/org-portal/src/routes/handoff/+page.svelte
@@ -1,34 +1,47 @@
 <script lang="ts">
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Input } from '@primer-paso/ui/input'
+import { Label } from '@primer-paso/ui/label'
+
 let { data } = $props()
 </script>
 
-<svelte:head>
-	<title>Borrador de certificado | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<svelte:head> <title>Certificate handoff | Primer Paso organisation portal</title> </svelte:head>
 
-<main class="shell">
-	<section class="card">
+<div class="stack-lg">
+	<header class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1>Borrador de certificado</h1>
+		<h1 class="page-title">Certificate handoff</h1>
+	</header>
 
-		{#if data.hasToken}
-			<p>
-				Se ha recibido una referencia de borrador. Inicia sesión como persona autorizada de la
-				organización para abrirlo.
-			</p>
-		{:else}
-			<p>
-				No se ha proporcionado ninguna referencia de borrador. Abre esta página desde un código QR
-				de Primer Paso o pega el enlace o código del borrador.
-			</p>
-			<form method="GET" action="/handoff">
-				<label>
-					Enlace o código del borrador
-					<input name="token" autocomplete="off">
-				</label>
-				<button type="submit">Abrir borrador</button>
-			</form>
+	<Card>
+		<CardHeader>
+			<CardTitle>
+				{#if data.hasToken}
+					Handoff reference received
+				{:else}
+					No handoff reference
+				{/if}
+			</CardTitle>
+			<CardDescription>
+				{#if data.hasToken}
+					Sign in as an authorised organisation user to open the draft.
+				{:else}
+					Open this page from a Primer Paso certificate handoff QR code or link.
+				{/if}
+			</CardDescription>
+		</CardHeader>
+		{#if !data.hasToken}
+			<CardContent>
+				<form method="GET" action="/handoff" class="stack">
+					<div class="form-field">
+						<Label for="token">Handoff token or link</Label>
+						<Input id="token" name="token" autocomplete="off" placeholder="Paste a token or URL" />
+					</div>
+					<div class="actions"><Button type="submit">Open handoff</Button></div>
+				</form>
+			</CardContent>
 		{/if}
-	</section>
-</main>
+	</Card>
+</div>

--- a/apps/org-portal/src/routes/login/+page.svelte
+++ b/apps/org-portal/src/routes/login/+page.svelte
@@ -7,22 +7,22 @@ import { Label } from '@primer-paso/ui/label'
 let { data, form } = $props()
 </script>
 
-<svelte:head> <title>Sign in | Primer Paso organisation portal</title> </svelte:head>
+<svelte:head> <title>Iniciar sesión | Portal de organizaciones de Primer Paso</title> </svelte:head>
 
 <div class="stack-lg">
 	<div class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1 class="page-title">Sign in to the organisation portal</h1>
+		<h1 class="page-title">Iniciar sesión en el portal de organizaciones</h1>
 	</div>
 
 	<Card>
 		<CardHeader>
-			<CardTitle>Send a sign-in link</CardTitle>
+			<CardTitle>Enviar enlace de acceso</CardTitle>
 			<CardDescription>
 				{#if data.hasPendingHandoff}
-					Sign in to open the certificate handoff.
+					Inicia sesión para abrir el borrador de certificado.
 				{:else}
-					Enter your organisation email. We'll send you a secure sign-in link.
+					Introduce el correo de tu organización. Te enviaremos un enlace de acceso seguro.
 				{/if}
 			</CardDescription>
 		</CardHeader>
@@ -30,20 +30,20 @@ let { data, form } = $props()
 			{#if form?.success}
 				<div class="panel-subtle" role="status">
 					<p class="text-pretty">
-						{form.message ?? 'Check your email. The sign-in link will open this portal.'}
+						{form.message ?? 'Revisa tu correo. El enlace de acceso abrirá este portal.'}
 					</p>
 				</div>
 			{:else}
 				{#if form?.error}
 					<div class="error-summary" role="alert">
-						<p class="error-summary-title">Could not send sign-in link</p>
+						<p class="error-summary-title">No se pudo enviar el enlace de acceso</p>
 						<p class="error-text">{form.error}</p>
 					</div>
 				{/if}
 				<form method="POST" class="stack">
 					<input type="hidden" name="next" value={data.next}>
 					<div class="form-field">
-						<Label for="email">Organisation email</Label>
+						<Label for="email">Correo de la organización</Label>
 						<Input
 							id="email"
 							name="email"
@@ -53,12 +53,14 @@ let { data, form } = $props()
 							value={form?.email ?? data.email ?? ''}
 						/>
 					</div>
-					<div class="actions"><Button type="submit">Send sign-in link</Button></div>
+					<div class="actions"><Button type="submit">Enviar enlace de acceso</Button></div>
 				</form>
 			{/if}
 
 			{#if !form?.success}
-				<p class="hint">Access is limited to authorised members of collaborating organisations.</p>
+				<p class="hint">
+					El acceso está limitado a miembros activos de organizaciones colaboradoras.
+				</p>
 			{/if}
 		</CardContent>
 	</Card>

--- a/apps/org-portal/src/routes/login/+page.svelte
+++ b/apps/org-portal/src/routes/login/+page.svelte
@@ -1,48 +1,65 @@
 <script lang="ts">
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Input } from '@primer-paso/ui/input'
+import { Label } from '@primer-paso/ui/label'
+
 let { data, form } = $props()
 </script>
 
-<svelte:head>
-	<title>Iniciar sesión | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
-</svelte:head>
+<svelte:head> <title>Sign in | Primer Paso organisation portal</title> </svelte:head>
 
-<main class="shell">
-	<section class="card">
+<div class="stack-lg">
+	<div class="section-block">
 		<p class="eyebrow">Primer Paso</p>
-		<h1>Iniciar sesión en el portal de organizaciones</h1>
+		<h1 class="page-title">Sign in to the organisation portal</h1>
+	</div>
 
-		{#if data.hasPendingHandoff}
-			<p>Inicia sesión para abrir el borrador de certificado.</p>
-		{:else}
-			<p>Introduce el correo de tu organización. Te enviaremos un enlace de acceso seguro.</p>
-		{/if}
-
-		{#if form?.success}
-			<p role="status">
-				{form.message ?? 'Revisa tu correo. El enlace de acceso abrirá este portal.'}
-			</p>
-		{:else}
-			{#if form?.error}
-				<p role="alert">{form.error}</p>
+	<Card>
+		<CardHeader>
+			<CardTitle>Send a sign-in link</CardTitle>
+			<CardDescription>
+				{#if data.hasPendingHandoff}
+					Sign in to open the certificate handoff.
+				{:else}
+					Enter your organisation email. We'll send you a secure sign-in link.
+				{/if}
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="stack">
+			{#if form?.success}
+				<div class="panel-subtle" role="status">
+					<p class="text-pretty">
+						{form.message ?? 'Check your email. The sign-in link will open this portal.'}
+					</p>
+				</div>
+			{:else}
+				{#if form?.error}
+					<div class="error-summary" role="alert">
+						<p class="error-summary-title">Could not send sign-in link</p>
+						<p class="error-text">{form.error}</p>
+					</div>
+				{/if}
+				<form method="POST" class="stack">
+					<input type="hidden" name="next" value={data.next}>
+					<div class="form-field">
+						<Label for="email">Organisation email</Label>
+						<Input
+							id="email"
+							name="email"
+							type="email"
+							autocomplete="email"
+							required
+							value={form?.email ?? data.email ?? ''}
+						/>
+					</div>
+					<div class="actions"><Button type="submit">Send sign-in link</Button></div>
+				</form>
 			{/if}
-			<form method="POST" class="stack">
-				<input type="hidden" name="next" value={data.next}>
-				<label for="email">Correo de la organización</label>
-				<input
-					id="email"
-					name="email"
-					type="email"
-					autocomplete="email"
-					required
-					value={form?.email ?? data.email ?? ''}
-				>
-				<button type="submit">Enviar enlace de acceso</button>
-			</form>
-		{/if}
 
-		{#if !form?.success}
-			<p>El acceso está limitado a miembros activos de organizaciones colaboradoras.</p>
-		{/if}
-	</section>
-</main>
+			{#if !form?.success}
+				<p class="hint">Access is limited to authorised members of collaborating organisations.</p>
+			{/if}
+		</CardContent>
+	</Card>
+</div>

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { reviewStatusLabel, vulnerabilityReasonLabel } from '$lib/labels'
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
+import DownloadIcon from '@lucide/svelte/icons/download'
+import { Badge } from '@primer-paso/ui/badge'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Separator } from '@primer-paso/ui/separator'
 
 let { data, form } = $props()
 
@@ -29,157 +34,213 @@ const location = $derived(data.draft.userData.location)
 const vulnerability = $derived(data.draft.userData.vulnerability)
 const review = $derived(data.review)
 const verification = $derived(formVerification ?? review.verification ?? emptyVerification)
+
+const statusTone = $derived(
+	review.status === 'issued' ? 'success' : review.status === 'ready_to_issue' ? 'info' : 'warning'
+)
 </script>
 
 <svelte:head>
-	<title>Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title>
-	<meta name="robots" content="noindex, nofollow">
+	<title>Review certificate handoff | Primer Paso organisation portal</title>
 </svelte:head>
 
-<main class="shell">
-	<section class="card">
-		<p class="eyebrow">Borrador de certificado</p>
-		<h1>Revisar el borrador del certificado</h1>
+<div class="stack-lg">
+	<header class="section-block">
+		<p class="eyebrow">Certificate handoff</p>
+		<h1 class="page-title">Review certificate draft</h1>
+		<div class="actions">
+			<span class="status-pill" data-tone={statusTone}>{review.status}</span>
+		</div>
+	</header>
 
-		{#if form?.error}
-			<p role="alert">{form.error}</p>
-		{/if}
+	{#if form?.error}
+		<div class="error-summary" role="alert">
+			<p class="error-summary-title">Could not save review</p>
+			<p class="error-text">{form.error}</p>
+		</div>
+	{/if}
 
-		<p>
-			Este borrador ha sido preparado por la persona solicitante. Antes de emitir el certificado,
-			comprueba la información con la persona y confirma que la organización puede acreditar las
-			circunstancias indicadas.
+	<div class="panel-subtle">
+		<p class="supporting-text">
+			This is a user-prepared draft. Do not issue a certificate unless your organisation has checked
+			the information and can certify the circumstances.
 		</p>
+	</div>
 
-		<section>
-			<h2>Estado de la revisión</h2>
-			<p><strong>{reviewStatusLabel(data.review.status)}</strong></p>
-		</section>
-
-		<section>
-			<h2>Datos de identidad</h2>
-			<dl>
-				<div>
-					<dt>Nombres</dt>
-					<dd>{identity.givenNames}</dd>
+	<Card>
+		<CardHeader> <CardTitle>Identity details</CardTitle> </CardHeader>
+		<CardContent>
+			<dl class="summary-grid">
+				<div class="summary-item">
+					<dt class="summary-label">Given names</dt>
+					<dd class="summary-value">{identity.givenNames}</dd>
 				</div>
-				<div>
-					<dt>Apellidos</dt>
-					<dd>{identity.familyNames}</dd>
+				<div class="summary-item">
+					<dt class="summary-label">Family names</dt>
+					<dd class="summary-value">{identity.familyNames}</dd>
 				</div>
-				<div>
-					<dt>Tipo de documento</dt>
-					<dd>{identity.documentType}</dd>
+				<div class="summary-item">
+					<dt class="summary-label">Document type</dt>
+					<dd class="summary-value">{identity.documentType}</dd>
 				</div>
-				<div>
-					<dt>Número de documento</dt>
-					<dd>{identity.documentNumber}</dd>
+				<div class="summary-item">
+					<dt class="summary-label">Document number</dt>
+					<dd class="summary-value">{identity.documentNumber}</dd>
 				</div>
 				{#if identity.dateOfBirth}
-					<div>
-						<dt>Fecha de nacimiento</dt>
-						<dd>{identity.dateOfBirth}</dd>
+					<div class="summary-item">
+						<dt class="summary-label">Date of birth</dt>
+						<dd class="summary-value">{identity.dateOfBirth}</dd>
 					</div>
 				{/if}
 				{#if identity.nationality}
-					<div>
-						<dt>Nacionalidad</dt>
-						<dd>{identity.nationality}</dd>
+					<div class="summary-item">
+						<dt class="summary-label">Nationality</dt>
+						<dd class="summary-value">{identity.nationality}</dd>
 					</div>
 				{/if}
 			</dl>
-		</section>
+		</CardContent>
+	</Card>
 
-		<section>
-			<h2>Contacto y dirección</h2>
-			<dl>
-				<div>
-					<dt>Correo electrónico</dt>
-					<dd>{contact.email}</dd>
+	<Card>
+		<CardHeader> <CardTitle>Contact and address</CardTitle> </CardHeader>
+		<CardContent>
+			<dl class="summary-grid">
+				<div class="summary-item">
+					<dt class="summary-label">Email</dt>
+					<dd class="summary-value">{contact.email}</dd>
 				</div>
 				{#if contact.phone}
-					<div>
-						<dt>Teléfono</dt>
-						<dd>{contact.phone}</dd>
+					<div class="summary-item">
+						<dt class="summary-label">Phone</dt>
+						<dd class="summary-value">{contact.phone}</dd>
 					</div>
 				{/if}
-				<div>
-					<dt>Dirección</dt>
-					<dd>
+				<div class="summary-item">
+					<dt class="summary-label">Address</dt>
+					<dd class="summary-value">
 						{location.addressLine1}
 						{#if location.addressLine2}
 							, {location.addressLine2}
 						{/if}
 					</dd>
 				</div>
-				<div>
-					<dt>Municipio</dt>
-					<dd>{location.municipality}</dd>
+				<div class="summary-item">
+					<dt class="summary-label">Municipality</dt>
+					<dd class="summary-value">{location.municipality}</dd>
 				</div>
-				<div>
-					<dt>Provincia</dt>
-					<dd>{location.province}</dd>
+				<div class="summary-item">
+					<dt class="summary-label">Province</dt>
+					<dd class="summary-value">{location.province}</dd>
 				</div>
 				{#if location.postalCode}
-					<div>
-						<dt>Código postal</dt>
-						<dd>{location.postalCode}</dd>
+					<div class="summary-item">
+						<dt class="summary-label">Postcode</dt>
+						<dd class="summary-value">{location.postalCode}</dd>
 					</div>
 				{/if}
 			</dl>
-		</section>
+		</CardContent>
+	</Card>
 
-		<section>
-			<h2>Circunstancias de vulnerabilidad</h2>
-			<ul>
+	<Card>
+		<CardHeader> <CardTitle>Vulnerability circumstances</CardTitle> </CardHeader>
+		<CardContent>
+			<ul class="grid gap-2 list-disc ps-5">
 				{#each vulnerability.reasons as reason}
 					<li>{vulnerabilityReasonLabel(reason)}</li>
 				{/each}
 			</ul>
-		</section>
+		</CardContent>
+	</Card>
 
-		<form method="POST" action="?/save">
-			<h2>Confirmaciones de verificación</h2>
-			<label>
-				<input
-					type="checkbox"
-					name="passportOrIdentityDocumentChecked"
-					value="yes"
-					checked={verification.passportOrIdentityDocumentChecked}
-				>
-				He comprobado el documento de identidad si la persona lo ha aportado.
-			</label>
-			<label>
-				<input
-					type="checkbox"
-					name="userInformationConfirmed"
-					value="yes"
-					checked={verification.userInformationConfirmed}
-				>
-				He confirmado estos datos con la persona.
-			</label>
-			<label>
-				<input
-					type="checkbox"
-					name="vulnerabilityInformationReviewed"
-					value="yes"
-					checked={verification.vulnerabilityInformationReviewed}
-				>
-				He revisado las circunstancias de vulnerabilidad.
-			</label>
-			<p>Estas confirmaciones quedarán registradas en el historial de auditoría.</p>
-			<button type="submit">Guardar confirmaciones</button>
-			{#if data.canMarkReadyToIssue}
-				<button type="submit" formaction="?/ready">Marcar como lista para emitir</button>
-			{/if}
-		</form>
-		{#if data.canIssueCertificate}
-			<form method="POST" action="?/issue"><button type="submit">Emitir certificado</button></form>
-		{/if}
-		{#if data.certificateHref}
-			<p><a href={data.certificateHref}>Descargar certificado emitido</a></p>
-		{/if}
+	<Card>
+		<CardHeader>
+			<CardTitle>Verification confirmations</CardTitle>
+			<CardDescription>This review action is recorded in the audit log.</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<form method="POST" action="?/save" class="stack">
+				<div class="check-list">
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="passportOrIdentityDocumentChecked"
+							value="yes"
+							checked={verification.passportOrIdentityDocumentChecked}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6">
+							I checked the identity document where available.
+						</span>
+					</label>
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="userInformationConfirmed"
+							value="yes"
+							checked={verification.userInformationConfirmed}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6"> I confirmed these details with the person. </span>
+					</label>
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="vulnerabilityInformationReviewed"
+							value="yes"
+							checked={verification.vulnerabilityInformationReviewed}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6"> I reviewed the vulnerability circumstances. </span>
+					</label>
+				</div>
+				<Separator />
+				<div class="actions">
+					<Button type="submit">Save review</Button>
+					{#if data.canMarkReadyToIssue}
+						<Button type="submit" formaction="?/ready" variant="secondary">
+							Mark ready to issue
+						</Button>
+					{/if}
+				</div>
+			</form>
+		</CardContent>
+	</Card>
 
-		<p><a href="/dashboard">Volver al panel de la organización</a></p>
-	</section>
-</main>
+	{#if data.canIssueCertificate}
+		<Card>
+			<CardHeader>
+				<CardTitle>Issue certificate</CardTitle>
+				<CardDescription>
+					You can issue the certificate now that the review is ready.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<form method="POST" action="?/issue">
+					<Button type="submit" variant="success">Issue certificate</Button>
+				</form>
+			</CardContent>
+		</Card>
+	{/if}
+
+	{#if data.certificateHref}
+		<Card>
+			<CardHeader> <CardTitle>Issued certificate</CardTitle> </CardHeader>
+			<CardContent>
+				<Button href={data.certificateHref} variant="outline">
+					<DownloadIcon class="size-4" aria-hidden="true" />
+					Download issued certificate
+				</Button>
+			</CardContent>
+		</Card>
+	{/if}
+
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Back to dashboard
+		</Button>
+	</div>
+</div>

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
 import DownloadIcon from '@lucide/svelte/icons/download'
 import { Badge } from '@primer-paso/ui/badge'
 import { Button } from '@primer-paso/ui/button'
@@ -236,11 +235,4 @@ const statusTone = $derived(
 			</CardContent>
 		</Card>
 	{/if}
-
-	<div class="actions">
-		<Button href="/dashboard" variant="ghost">
-			<ArrowLeftIcon class="size-4" aria-hidden="true" />
-			Back to dashboard
-		</Button>
-	</div>
 </div>

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
 import DownloadIcon from '@lucide/svelte/icons/download'
-import { Badge } from '@primer-paso/ui/badge'
 import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import { Separator } from '@primer-paso/ui/separator'
+import { reviewStatusLabel, vulnerabilityReasonLabel } from '$lib/labels'
 
 let { data, form } = $props()
 
@@ -40,61 +41,62 @@ const statusTone = $derived(
 </script>
 
 <svelte:head>
-	<title>Review certificate handoff | Primer Paso organisation portal</title>
+	<title>Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title>
 </svelte:head>
 
 <div class="stack-lg">
 	<header class="section-block">
-		<p class="eyebrow">Certificate handoff</p>
-		<h1 class="page-title">Review certificate draft</h1>
+		<p class="eyebrow">Borrador de certificado</p>
+		<h1 class="page-title">Revisar el borrador del certificado</h1>
 		<div class="actions">
-			<span class="status-pill" data-tone={statusTone}>{review.status}</span>
+			<span class="status-pill" data-tone={statusTone}>{reviewStatusLabel(review.status)}</span>
 		</div>
 	</header>
 
 	{#if form?.error}
 		<div class="error-summary" role="alert">
-			<p class="error-summary-title">Could not save review</p>
+			<p class="error-summary-title">No se pudo guardar la revisión</p>
 			<p class="error-text">{form.error}</p>
 		</div>
 	{/if}
 
 	<div class="panel-subtle">
 		<p class="supporting-text">
-			This is a user-prepared draft. Do not issue a certificate unless your organisation has checked
-			the information and can certify the circumstances.
+			Este borrador ha sido preparado por la persona solicitante. Antes de emitir el certificado,
+			comprueba la información con la persona y confirma que la organización puede acreditar las
+			circunstancias indicadas.
 		</p>
 	</div>
 
 	<Card>
-		<CardHeader> <CardTitle>Identity details</CardTitle> </CardHeader>
+		<CardHeader> <CardTitle>Datos de identidad</CardTitle> </CardHeader>
 		<CardContent>
 			<dl class="summary-grid">
 				<div class="summary-item">
-					<dt class="summary-label">Given names</dt>
+					<dt class="summary-label">Nombres</dt>
 					<dd class="summary-value">{identity.givenNames}</dd>
 				</div>
 				<div class="summary-item">
-					<dt class="summary-label">Family names</dt>
+					<dt class="summary-label">Apellidos</dt>
 					<dd class="summary-value">{identity.familyNames}</dd>
 				</div>
 				<div class="summary-item">
-					<dt class="summary-label">Document type</dt>
+					<dt class="summary-label">Tipo de documento</dt>
 					<dd class="summary-value">{identity.documentType}</dd>
 				</div>
 				<div class="summary-item">
-					<dt class="summary-label">Document number</dt>
+					<dt class="summary-label">Número de documento</dt>
 					<dd class="summary-value">{identity.documentNumber}</dd>
 				</div>
 				{#if identity.dateOfBirth}
 					<div class="summary-item">
-						<dt class="summary-label">Date of birth</dt>
+						<dt class="summary-label">Fecha de nacimiento</dt>
 						<dd class="summary-value">{identity.dateOfBirth}</dd>
 					</div>
 				{/if}
 				{#if identity.nationality}
 					<div class="summary-item">
-						<dt class="summary-label">Nationality</dt>
+						<dt class="summary-label">Nacionalidad</dt>
 						<dd class="summary-value">{identity.nationality}</dd>
 					</div>
 				{/if}
@@ -103,21 +105,21 @@ const statusTone = $derived(
 	</Card>
 
 	<Card>
-		<CardHeader> <CardTitle>Contact and address</CardTitle> </CardHeader>
+		<CardHeader> <CardTitle>Contacto y dirección</CardTitle> </CardHeader>
 		<CardContent>
 			<dl class="summary-grid">
 				<div class="summary-item">
-					<dt class="summary-label">Email</dt>
+					<dt class="summary-label">Correo electrónico</dt>
 					<dd class="summary-value">{contact.email}</dd>
 				</div>
 				{#if contact.phone}
 					<div class="summary-item">
-						<dt class="summary-label">Phone</dt>
+						<dt class="summary-label">Teléfono</dt>
 						<dd class="summary-value">{contact.phone}</dd>
 					</div>
 				{/if}
 				<div class="summary-item">
-					<dt class="summary-label">Address</dt>
+					<dt class="summary-label">Dirección</dt>
 					<dd class="summary-value">
 						{location.addressLine1}
 						{#if location.addressLine2}
@@ -126,16 +128,16 @@ const statusTone = $derived(
 					</dd>
 				</div>
 				<div class="summary-item">
-					<dt class="summary-label">Municipality</dt>
+					<dt class="summary-label">Municipio</dt>
 					<dd class="summary-value">{location.municipality}</dd>
 				</div>
 				<div class="summary-item">
-					<dt class="summary-label">Province</dt>
+					<dt class="summary-label">Provincia</dt>
 					<dd class="summary-value">{location.province}</dd>
 				</div>
 				{#if location.postalCode}
 					<div class="summary-item">
-						<dt class="summary-label">Postcode</dt>
+						<dt class="summary-label">Código postal</dt>
 						<dd class="summary-value">{location.postalCode}</dd>
 					</div>
 				{/if}
@@ -144,7 +146,7 @@ const statusTone = $derived(
 	</Card>
 
 	<Card>
-		<CardHeader> <CardTitle>Vulnerability circumstances</CardTitle> </CardHeader>
+		<CardHeader> <CardTitle>Circunstancias de vulnerabilidad</CardTitle> </CardHeader>
 		<CardContent>
 			<ul class="grid gap-2 list-disc ps-5">
 				{#each vulnerability.reasons as reason}
@@ -156,8 +158,10 @@ const statusTone = $derived(
 
 	<Card>
 		<CardHeader>
-			<CardTitle>Verification confirmations</CardTitle>
-			<CardDescription>This review action is recorded in the audit log.</CardDescription>
+			<CardTitle>Confirmaciones de verificación</CardTitle>
+			<CardDescription>
+				Estas confirmaciones quedarán registradas en el historial de auditoría.
+			</CardDescription>
 		</CardHeader>
 		<CardContent>
 			<form method="POST" action="?/save" class="stack">
@@ -171,7 +175,7 @@ const statusTone = $derived(
 							class="mt-1 size-4"
 						>
 						<span class="text-sm leading-6">
-							I checked the identity document where available.
+							He comprobado el documento de identidad si la persona lo ha aportado.
 						</span>
 					</label>
 					<label class="check-row">
@@ -182,7 +186,7 @@ const statusTone = $derived(
 							checked={verification.userInformationConfirmed}
 							class="mt-1 size-4"
 						>
-						<span class="text-sm leading-6"> I confirmed these details with the person. </span>
+						<span class="text-sm leading-6">He confirmado estos datos con la persona.</span>
 					</label>
 					<label class="check-row">
 						<input
@@ -192,15 +196,15 @@ const statusTone = $derived(
 							checked={verification.vulnerabilityInformationReviewed}
 							class="mt-1 size-4"
 						>
-						<span class="text-sm leading-6"> I reviewed the vulnerability circumstances. </span>
+						<span class="text-sm leading-6">He revisado las circunstancias de vulnerabilidad.</span>
 					</label>
 				</div>
 				<Separator />
 				<div class="actions">
-					<Button type="submit">Save review</Button>
+					<Button type="submit">Guardar confirmaciones</Button>
 					{#if data.canMarkReadyToIssue}
 						<Button type="submit" formaction="?/ready" variant="secondary">
-							Mark ready to issue
+							Marcar como lista para emitir
 						</Button>
 					{/if}
 				</div>
@@ -211,14 +215,14 @@ const statusTone = $derived(
 	{#if data.canIssueCertificate}
 		<Card>
 			<CardHeader>
-				<CardTitle>Issue certificate</CardTitle>
+				<CardTitle>Emitir certificado</CardTitle>
 				<CardDescription>
-					You can issue the certificate now that the review is ready.
+					Puedes emitir el certificado ahora que la revisión está lista.
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
 				<form method="POST" action="?/issue">
-					<Button type="submit" variant="success">Issue certificate</Button>
+					<Button type="submit" variant="success">Emitir certificado</Button>
 				</form>
 			</CardContent>
 		</Card>
@@ -226,13 +230,20 @@ const statusTone = $derived(
 
 	{#if data.certificateHref}
 		<Card>
-			<CardHeader> <CardTitle>Issued certificate</CardTitle> </CardHeader>
+			<CardHeader> <CardTitle>Certificado emitido</CardTitle> </CardHeader>
 			<CardContent>
 				<Button href={data.certificateHref} variant="outline">
 					<DownloadIcon class="size-4" aria-hidden="true" />
-					Download issued certificate
+					Descargar certificado emitido
 				</Button>
 			</CardContent>
 		</Card>
 	{/if}
+
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Volver al panel
+		</Button>
+	</div>
 </div>


### PR DESCRIPTION
## Summary
- Restyle org-portal with updated `app.css` and refreshed layout
- Add navigation in `+layout.svelte` and an `+error.svelte` page
- Update admin (audit, members), dashboard, handoff, login, and review pages to match the new look

## Test plan
- [ ] Run the org-portal dev server and walk through `/`, `/login`, `/dashboard`, `/handoff`, `/admin/audit`, `/admin/members`, and `/reviews/[id]`
- [ ] Verify navigation renders correctly across routes
- [ ] Trigger an error to confirm `+error.svelte` displays as expected
- [ ] Sanity-check responsive/mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)