### PR TITLE
chore(pdf-signer): move pdf-signer github action

### DIFF
--- a/.github/workflows/pdf-signer.yml
+++ b/.github/workflows/pdf-signer.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PDF signer
 
 on:
   pull_request:
@@ -6,32 +6,47 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: pdf-signer-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    working-directory: services/pdf-signer
 
 jobs:
-  test:
+  verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version-file: ".python-version"
-      - uses: astral-sh/setup-uv@v7
+          python-version-file: services/pdf-signer/.python-version
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+
       - name: Install dependencies
         run: uv sync --locked --dev
+
       - name: Lint
         run: uv run ruff check .
+
       - name: Format check
         run: uv run ruff format --check .
+
       - name: Type check
         run: uv run pyright
+
       - name: Test
         run: uv run pytest
-


### PR DESCRIPTION
## What changed?

Moved pdf-signer github action to root as it previously wasn't picked up.

## Risk level

- [ ] Low: copy, docs, styling, tests only
- [ ] Medium: app logic, validation, routing, dependencies
- [x] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


