### PR TITLE
feat(org-portal): allow admin to upload certificate

### DIFF
--- a/apps/org-portal/src/lib/labels.ts
+++ b/apps/org-portal/src/lib/labels.ts
@@ -61,7 +61,11 @@ export const auditEventLabel = (eventType: string) =>
 		'certificate.downloaded': 'Certificado descargado',
 		'organisation.member_saved': 'Miembro guardado',
 		'organisation.member_role_updated': 'Rol de miembro actualizado',
-		'organisation.member_disabled': 'Miembro desactivado'
+		'organisation.member_disabled': 'Miembro desactivado',
+		'organisation.profile_updated': 'Datos de organización actualizados',
+		'organisation.signing_certificate_replaced': 'Certificado de firma reemplazado',
+		'organisation.signing_certificate_replace_failed': 'Error al reemplazar certificado de firma',
+		'organisation.signing_certificate_disabled': 'Certificado de firma desactivado'
 	})[eventType] ?? eventType
 
 const auditEventDataKeyLabel = (key: string) =>
@@ -75,7 +79,15 @@ const auditEventDataKeyLabel = (key: string) =>
 		referenceCode: 'código de referencia',
 		blockedUntil: 'bloqueado hasta',
 		filename: 'archivo',
-		issuedCertificateId: 'certificado emitido'
+		issuedCertificateId: 'certificado emitido',
+		signingCertificateId: 'certificado de firma',
+		signingCertificateFingerprintSha256: 'huella SHA-256 del certificado',
+		fingerprintSha256: 'huella SHA-256',
+		subject: 'titular',
+		issuer: 'emisor',
+		notAfter: 'válido hasta',
+		message: 'mensaje',
+		organisationId: 'organización'
 	})[key] ?? key
 
 const auditEventDataValueLabel = (key: string, value: unknown) => {

--- a/apps/org-portal/src/routes/+layout.svelte
+++ b/apps/org-portal/src/routes/+layout.svelte
@@ -14,6 +14,9 @@ const navItems = $derived(
 				...(session.permissions.includes('organisation:manage_members')
 					? [{ href: '/admin/members', label: 'Miembros' }]
 					: []),
+				...(session.permissions.includes('organisation:manage_profile')
+					? [{ href: '/admin/organisation', label: 'Organización' }]
+					: []),
 				...(session.permissions.includes('audit:read')
 					? [{ href: '/admin/audit', label: 'Auditoría' }]
 					: [])

--- a/apps/org-portal/src/routes/admin/organisation/+page.server.ts
+++ b/apps/org-portal/src/routes/admin/organisation/+page.server.ts
@@ -1,0 +1,317 @@
+import { OrgPortalRepositoryError } from '@primer-paso/db'
+import { inspectSigningCertificate } from '@primer-paso/signing-client'
+import { error, fail, redirect } from '@sveltejs/kit'
+import { env } from '$env/dynamic/private'
+import { writeAuditEvent } from '$lib/server/audit'
+import { requirePermission } from '$lib/server/auth'
+import { getOrgPortalRepository } from '$lib/server/repository'
+import { encryptSigningSecret, encryptSigningText } from '$lib/server/signing-secret-crypto'
+import type { Actions, PageServerLoad } from './$types'
+
+const MAX_PKCS12_BYTES = 1024 * 1024
+const ENTITY_TYPES = ['public_administration', 'third_sector_or_union'] as const
+
+type EntityType = (typeof ENTITY_TYPES)[number]
+
+const isEntityType = (value: string): value is EntityType =>
+	ENTITY_TYPES.includes(value as EntityType)
+
+const readString = (formData: FormData, key: string) =>
+	String(formData.get(key) ?? '')
+		.replace(/\s+/g, ' ')
+		.trim()
+
+const normaliseOptionalString = (value: string) => (value ? value : undefined)
+
+const getRepositoryOrError = () => {
+	const repository = getOrgPortalRepository()
+	if (!repository) {
+		error(503, 'El almacenamiento del portal de organizaciones no está configurado.')
+	}
+	return repository
+}
+
+const certificateFailureMessage = (caught: unknown) => {
+	if (caught instanceof Error && caught.message.includes('HTTP 400')) {
+		return 'No se pudo abrir el certificado. Comprueba que el archivo y la contraseña sean correctos.'
+	}
+	if (caught instanceof Error && caught.message.includes('HTTP 401')) {
+		return 'El servicio interno de firma rechazó la validación del certificado.'
+	}
+	if (caught instanceof Error && caught.message.includes('HTTP 503')) {
+		return 'El servicio interno de firma no está configurado.'
+	}
+	return 'No se pudo validar el certificado. Comprueba que el archivo y la contraseña sean correctos.'
+}
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const session = requirePermission(locals, 'organisation:manage_profile')
+	const repository = getRepositoryOrError()
+
+	const [organisation, signingCertificate] = await Promise.all([
+		repository.findOrganisationById(session.organisationId),
+		repository.findActiveOrganisationSigningCertificate(session.organisationId)
+	])
+
+	if (!organisation) {
+		error(404, 'Organización no encontrada.')
+	}
+
+	return {
+		organisation,
+		signingCertificate: signingCertificate
+			? {
+					id: signingCertificate.id,
+					subject: signingCertificate.subject,
+					issuer: signingCertificate.issuer,
+					serialNumber: signingCertificate.serialNumber,
+					fingerprintSha256: signingCertificate.fingerprintSha256,
+					notBefore: signingCertificate.notBefore,
+					notAfter: signingCertificate.notAfter,
+					createdAt: signingCertificate.createdAt
+				}
+			: null
+	}
+}
+
+export const actions: Actions = {
+	profile: async ({ locals, request }) => {
+		const session = requirePermission(locals, 'organisation:manage_profile')
+		const repository = getRepositoryOrError()
+		const formData = await request.formData()
+
+		const name = readString(formData, 'name')
+		const entityType = readString(formData, 'entityType')
+		const registrationNumber = readString(formData, 'registrationNumber')
+		const nifCif = readString(formData, 'nifCif')
+		const address = readString(formData, 'address')
+		const email = readString(formData, 'email')
+		const phone = readString(formData, 'phone')
+
+		const value = {
+			name,
+			entityType,
+			registrationNumber,
+			nifCif,
+			address,
+			email,
+			phone
+		}
+
+		if (!name) {
+			return fail(400, {
+				intent: 'profile',
+				error: 'Introduce el nombre de la organización.',
+				value
+			})
+		}
+
+		if (!isEntityType(entityType)) {
+			return fail(400, {
+				intent: 'profile',
+				error: 'Elige un tipo de entidad válido.',
+				value
+			})
+		}
+
+		if (email && !email.includes('@')) {
+			return fail(400, {
+				intent: 'profile',
+				error: 'Introduce una dirección de correo electrónico válida.',
+				value
+			})
+		}
+
+		try {
+			const organisation = await repository.updateOrganisationProfile({
+				organisationId: session.organisationId,
+				name,
+				entityType,
+				registrationNumber: normaliseOptionalString(registrationNumber),
+				nifCif: normaliseOptionalString(nifCif),
+				address: normaliseOptionalString(address),
+				email: normaliseOptionalString(email),
+				phone: normaliseOptionalString(phone)
+			})
+
+			await writeAuditEvent({
+				eventType: 'organisation.profile_updated',
+				eventData: {
+					organisationId: organisation.id
+				},
+				organisationId: session.organisationId,
+				memberId: session.memberId,
+				request
+			})
+		} catch (caught) {
+			return fail(400, {
+				intent: 'profile',
+				error:
+					caught instanceof OrgPortalRepositoryError
+						? 'No se encontró la organización.'
+						: 'No se pudieron guardar los datos de la organización.',
+				value
+			})
+		}
+
+		redirect(303, '/admin/organisation')
+	},
+
+	certificate: async ({ locals, request }) => {
+		const session = requirePermission(locals, 'organisation:manage_profile')
+		const repository = getRepositoryOrError()
+
+		const signerUrl = env.PRIVATE_PDF_SIGNER_URL?.trim()
+		const signerToken = env.PRIVATE_PDF_SIGNER_TOKEN?.trim()
+		const encryptionKey = env.PRIVATE_SIGNING_CERT_ENCRYPTION_KEY?.trim()
+
+		if (!signerUrl || !signerToken || !encryptionKey) {
+			return fail(500, {
+				intent: 'certificate',
+				error: 'La validación de certificados de firma no está configurada.'
+			})
+		}
+
+		const formData = await request.formData()
+		const uploaded = formData.get('pkcs12')
+		const passphrase = String(formData.get('passphrase') ?? '')
+		const confirmed = formData.get('confirmSigningUse') === 'yes'
+
+		if (!(uploaded instanceof File) || uploaded.size === 0) {
+			return fail(400, {
+				intent: 'certificate',
+				error: 'Sube un certificado de firma en formato .p12 o .pfx.'
+			})
+		}
+
+		if (uploaded.size > MAX_PKCS12_BYTES) {
+			return fail(400, {
+				intent: 'certificate',
+				error: 'El certificado es demasiado grande. El tamaño máximo permitido es 1 MB.'
+			})
+		}
+
+		const filename = uploaded.name.toLowerCase()
+		if (!filename.endsWith('.p12') && !filename.endsWith('.pfx')) {
+			return fail(400, {
+				intent: 'certificate',
+				error: 'El archivo debe tener extensión .p12 o .pfx.'
+			})
+		}
+
+		if (!passphrase) {
+			return fail(400, {
+				intent: 'certificate',
+				error: 'Introduce la contraseña del certificado.'
+			})
+		}
+
+		if (!confirmed) {
+			return fail(400, {
+				intent: 'certificate',
+				error: 'Confirma que este certificado se usará para firmar certificados emitidos.'
+			})
+		}
+
+		try {
+			const pkcs12 = new Uint8Array(await uploaded.arrayBuffer())
+			const metadata = await inspectSigningCertificate({
+				serviceUrl: signerUrl,
+				serviceToken: signerToken,
+				pkcs12,
+				pkcs12Passphrase: passphrase
+			})
+
+			const now = new Date()
+			if (metadata.notBefore && metadata.notBefore.getTime() > now.getTime()) {
+				return fail(400, {
+					intent: 'certificate',
+					error: 'El certificado subido todavía no es válido.'
+				})
+			}
+
+			if (metadata.notAfter && metadata.notAfter.getTime() <= now.getTime()) {
+				return fail(400, {
+					intent: 'certificate',
+					error: 'El certificado subido está caducado.'
+				})
+			}
+
+			const signingCertificate = await repository.replaceOrganisationSigningCertificate({
+				organisationId: session.organisationId,
+				createdByMemberId: session.memberId,
+				encryptedPkcs12: encryptSigningSecret(pkcs12, encryptionKey),
+				encryptedPassphrase: encryptSigningText(passphrase, encryptionKey),
+				subject: metadata.signerSubject,
+				issuer: metadata.signerIssuer,
+				serialNumber: metadata.certificateSerialNumber,
+				fingerprintSha256: metadata.certificateFingerprintSha256,
+				notBefore: metadata.notBefore?.toISOString(),
+				notAfter: metadata.notAfter?.toISOString()
+			})
+
+			await writeAuditEvent({
+				eventType: 'organisation.signing_certificate_replaced',
+				eventData: {
+					signingCertificateId: signingCertificate.id,
+					fingerprintSha256: signingCertificate.fingerprintSha256,
+					subject: signingCertificate.subject,
+					issuer: signingCertificate.issuer,
+					notAfter: signingCertificate.notAfter
+				},
+				organisationId: session.organisationId,
+				memberId: session.memberId,
+				request
+			})
+		} catch (caught) {
+			await writeAuditEvent({
+				eventType: 'organisation.signing_certificate_replace_failed',
+				eventData: {
+					reason: 'certificate_validation_failed',
+					message: caught instanceof Error ? caught.message : 'Unknown certificate validation error'
+				},
+				organisationId: session.organisationId,
+				memberId: session.memberId,
+				request
+			})
+
+			return fail(400, {
+				intent: 'certificate',
+				error: certificateFailureMessage(caught)
+			})
+		}
+
+		redirect(303, '/admin/organisation')
+	},
+
+	disableCertificate: async ({ locals, request }) => {
+		const session = requirePermission(locals, 'organisation:manage_profile')
+		const repository = getRepositoryOrError()
+		const formData = await request.formData()
+		const certificateId = readString(formData, 'certificateId')
+
+		if (!certificateId) {
+			return fail(400, {
+				intent: 'disableCertificate',
+				error: 'No se encontró el certificado de firma activo.'
+			})
+		}
+
+		await repository.disableOrganisationSigningCertificate({
+			organisationId: session.organisationId,
+			certificateId
+		})
+
+		await writeAuditEvent({
+			eventType: 'organisation.signing_certificate_disabled',
+			eventData: {
+				signingCertificateId: certificateId
+			},
+			organisationId: session.organisationId,
+			memberId: session.memberId,
+			request
+		})
+
+		redirect(303, '/admin/organisation')
+	}
+}

--- a/apps/org-portal/src/routes/admin/organisation/+page.svelte
+++ b/apps/org-portal/src/routes/admin/organisation/+page.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
+import ShieldCheckIcon from '@lucide/svelte/icons/shield-check'
+import { Badge } from '@primer-paso/ui/badge'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Input } from '@primer-paso/ui/input'
+import { Label } from '@primer-paso/ui/label'
+import { NativeSelect, NativeSelectOption } from '@primer-paso/ui/native-select'
+import { Separator } from '@primer-paso/ui/separator'
+
+let { data, form } = $props()
+
+const organisationValue = $derived(
+	form?.intent === 'profile' && form.value ? form.value : data.organisation
+)
+
+const formatDate = (value: string | undefined) => {
+	if (!value) return '—'
+	return new Intl.DateTimeFormat('es-ES', {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+		timeZone: 'Europe/Madrid'
+	}).format(new Date(value))
+}
+
+const entityTypeLabel = (value: string) =>
+	({
+		public_administration: 'Administración pública',
+		third_sector_or_union: 'Tercer sector o sindicato'
+	})[value] ?? value
+
+const shortFingerprint = (value: string) =>
+	value.length > 24 ? `${value.slice(0, 12)}…${value.slice(-12)}` : value
+</script>
+
+<svelte:head> <title>Organización | Portal de organizaciones de Primer Paso</title> </svelte:head>
+
+<div class="stack-lg">
+	<header class="section-block">
+		<p class="eyebrow">Administración de la organización</p>
+		<h1 class="page-title">Datos de organización</h1>
+		<p class="supporting-text">
+			Actualiza la información que se utilizará al emitir certificados y configura el certificado de
+			firma de <strong>{data.organisation.name}</strong>.
+		</p>
+	</header>
+
+	{#if form?.error}
+		<div class="error-summary" role="alert">
+			<p class="error-summary-title">No se pudieron guardar los cambios</p>
+			<p class="error-text">{form.error}</p>
+		</div>
+	{/if}
+
+	<Card>
+		<CardHeader>
+			<CardTitle id="organisation-profile-title">Información de la organización</CardTitle>
+			<CardDescription>
+				Estos datos se incorporan al certificado emitido cuando corresponda.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<form
+				method="POST"
+				action="?/profile"
+				class="stack"
+				aria-labelledby="organisation-profile-title"
+			>
+				<div class="grid gap-4 md:grid-cols-2">
+					<div class="form-field md:col-span-2">
+						<Label for="name">Nombre de la organización</Label>
+						<Input
+							id="name"
+							name="name"
+							autocomplete="organization"
+							required
+							value={organisationValue.name ?? ''}
+						/>
+					</div>
+
+					<div class="form-field">
+						<Label for="entityType">Tipo de entidad</Label>
+						<NativeSelect id="entityType" name="entityType" required>
+							{#each ['third_sector_or_union', 'public_administration'] as entityType}
+								<NativeSelectOption
+									value={entityType}
+									selected={(organisationValue.entityType ?? 'third_sector_or_union') ===
+										entityType}
+								>
+									{entityTypeLabel(entityType)}
+								</NativeSelectOption>
+							{/each}
+						</NativeSelect>
+					</div>
+
+					<div class="form-field">
+						<Label for="nifCif">NIF/CIF</Label>
+						<Input id="nifCif" name="nifCif" value={organisationValue.nifCif ?? ''} />
+					</div>
+
+					<div class="form-field">
+						<Label for="registrationNumber">Número de registro</Label>
+						<Input
+							id="registrationNumber"
+							name="registrationNumber"
+							value={organisationValue.registrationNumber ?? ''}
+						/>
+					</div>
+
+					<div class="form-field">
+						<Label for="email">Correo electrónico</Label>
+						<Input
+							id="email"
+							name="email"
+							type="email"
+							autocomplete="email"
+							value={organisationValue.email ?? ''}
+						/>
+					</div>
+
+					<div class="form-field">
+						<Label for="phone">Teléfono</Label>
+						<Input
+							id="phone"
+							name="phone"
+							autocomplete="tel"
+							value={organisationValue.phone ?? ''}
+						/>
+					</div>
+
+					<div class="form-field md:col-span-2">
+						<Label for="address">Dirección</Label>
+						<Input
+							id="address"
+							name="address"
+							autocomplete="street-address"
+							value={organisationValue.address ?? ''}
+						/>
+					</div>
+				</div>
+
+				<div class="actions"><Button type="submit">Guardar datos</Button></div>
+			</form>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardHeader>
+			<CardTitle>
+				<span class="inline-flex items-center gap-2">
+					<ShieldCheckIcon class="size-5 text-muted-foreground" aria-hidden="true" />
+					Certificado de firma
+				</span>
+			</CardTitle>
+			<CardDescription>
+				El certificado se valida con el servicio interno de firma, se almacena cifrado y solo se usa
+				en el servidor para firmar PDFs emitidos.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="stack">
+			{#if data.signingCertificate}
+				<div class="panel-subtle stack-sm">
+					<div class="actions">
+						<Badge variant="success">Certificado activo</Badge>
+						<span class="hint">Creado: {formatDate(data.signingCertificate.createdAt)}</span>
+					</div>
+
+					<dl class="summary-grid">
+						<div class="summary-item">
+							<dt class="summary-label">Titular</dt>
+							<dd class="summary-value">{data.signingCertificate.subject}</dd>
+						</div>
+						<div class="summary-item">
+							<dt class="summary-label">Emisor</dt>
+							<dd class="summary-value">{data.signingCertificate.issuer}</dd>
+						</div>
+						<div class="summary-item">
+							<dt class="summary-label">Número de serie</dt>
+							<dd class="summary-value">{data.signingCertificate.serialNumber}</dd>
+						</div>
+						<div class="summary-item">
+							<dt class="summary-label">Huella SHA-256</dt>
+							<dd class="summary-value font-mono" title={data.signingCertificate.fingerprintSha256}>
+								{shortFingerprint(data.signingCertificate.fingerprintSha256)}
+							</dd>
+						</div>
+						<div class="summary-item">
+							<dt class="summary-label">Válido desde</dt>
+							<dd class="summary-value">{formatDate(data.signingCertificate.notBefore)}</dd>
+						</div>
+						<div class="summary-item">
+							<dt class="summary-label">Válido hasta</dt>
+							<dd class="summary-value">{formatDate(data.signingCertificate.notAfter)}</dd>
+						</div>
+					</dl>
+
+					<form method="POST" action="?/disableCertificate">
+						<input type="hidden" name="certificateId" value={data.signingCertificate.id}>
+						<Button type="submit" variant="destructive">Desactivar certificado</Button>
+					</form>
+				</div>
+			{:else}
+				<div class="panel-subtle">
+					<p class="supporting-text">
+						No hay ningún certificado de firma activo. La organización no podrá emitir certificados
+						firmados hasta que se configure uno.
+					</p>
+				</div>
+			{/if}
+
+			<Separator />
+
+			<form method="POST" action="?/certificate" enctype="multipart/form-data" class="stack">
+				<div class="grid gap-4 md:grid-cols-2">
+					<div class="form-field md:col-span-2">
+						<Label for="pkcs12">
+							{data.signingCertificate ? 'Reemplazar certificado' : 'Subir certificado'}
+						</Label>
+						<Input
+							id="pkcs12"
+							name="pkcs12"
+							type="file"
+							accept=".p12,.pfx,application/x-pkcs12"
+							required
+						/>
+						<p class="hint">
+							Sube un archivo .p12 o .pfx. No se podrá descargar ni ver después de guardarlo.
+						</p>
+					</div>
+
+					<div class="form-field md:col-span-2">
+						<Label for="passphrase">Contraseña del certificado</Label>
+						<Input
+							id="passphrase"
+							name="passphrase"
+							type="password"
+							autocomplete="new-password"
+							required
+						/>
+						<p class="hint">
+							La contraseña se valida antes de guardar el certificado y se almacena cifrada.
+						</p>
+					</div>
+				</div>
+
+				<label class="check-row">
+					<input type="checkbox" name="confirmSigningUse" value="yes" class="mt-1 size-4" required>
+					<span class="text-sm leading-6">
+						Entiendo que este certificado se usará para firmar los certificados emitidos por la
+						organización.
+					</span>
+				</label>
+
+				<div class="actions">
+					<Button type="submit" variant="secondary">
+						{data.signingCertificate ? 'Guardar reemplazo' : 'Guardar certificado'}
+					</Button>
+				</div>
+			</form>
+		</CardContent>
+	</Card>
+
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Volver al panel
+		</Button>
+	</div>
+</div>

--- a/apps/org-portal/src/routes/dashboard/+page.server.ts
+++ b/apps/org-portal/src/routes/dashboard/+page.server.ts
@@ -8,6 +8,7 @@ export const load: PageServerLoad = ({ locals, url }) => {
 		session,
 		permissionError: url.searchParams.get('error') === 'permission',
 		adminLinks: {
+			canManageOrganisation: session.permissions.includes('organisation:manage_profile'),
 			canManageMembers: session.permissions.includes('organisation:manage_members'),
 			canReadAudit: session.permissions.includes('audit:read')
 		}

--- a/apps/org-portal/src/routes/dashboard/+page.svelte
+++ b/apps/org-portal/src/routes/dashboard/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import Building2Icon from '@lucide/svelte/icons/building-2'
 import ClipboardListIcon from '@lucide/svelte/icons/clipboard-list'
 import HistoryIcon from '@lucide/svelte/icons/history'
 import UsersIcon from '@lucide/svelte/icons/users'
@@ -54,7 +55,7 @@ let { data } = $props()
 		</CardContent>
 	</Card>
 
-	{#if data.adminLinks.canManageMembers || data.adminLinks.canReadAudit}
+	{#if data.adminLinks.canManageOrganisation || data.adminLinks.canManageMembers || data.adminLinks.canReadAudit}
 		<Card>
 			<CardHeader>
 				<CardTitle>Administración de la organización</CardTitle>
@@ -62,6 +63,20 @@ let { data } = $props()
 			</CardHeader>
 			<CardContent>
 				<div class="grid gap-3 md:grid-cols-2">
+					{#if data.adminLinks.canManageOrganisation}
+						<a
+							href="/admin/organisation"
+							class="panel-subtle flex items-start gap-3 no-underline transition-colors hover:bg-accent/60"
+						>
+							<Building2Icon class="size-5 mt-0.5 text-muted-foreground" aria-hidden="true" />
+							<span class="grid gap-1">
+								<span class="section-title">Datos de organización</span>
+								<span class="hint">
+									Actualiza los datos de la organización y su certificado de firma.
+								</span>
+							</span>
+						</a>
+					{/if}
 					{#if data.adminLinks.canManageMembers}
 						<a
 							href="/admin/members"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
 		]
 	},
 	"devDependencies": {
+		"@primer-paso/db": "workspace:*",
+		"@primer-paso/signing-client": "workspace:*",
 		"@biomejs/biome": "2.4.8",
 		"@types/node": "^24",
 		"netlify-cli": "^25.0.1",

--- a/packages/db/src/org-portal.ts
+++ b/packages/db/src/org-portal.ts
@@ -194,6 +194,38 @@ export interface DisableOrganisationMemberInput {
 	now?: Date
 }
 
+export interface UpdateOrganisationProfileInput {
+	organisationId: string
+	name: string
+	registrationNumber?: string
+	nifCif?: string
+	address?: string
+	email?: string
+	phone?: string
+	entityType: OrganisationRecord['entityType']
+	now?: Date
+}
+
+export interface ReplaceOrganisationSigningCertificateInput {
+	organisationId: string
+	createdByMemberId: string | null
+	encryptedPkcs12: string
+	encryptedPassphrase: string
+	subject: string
+	issuer: string
+	serialNumber: string
+	fingerprintSha256: string
+	notBefore?: string
+	notAfter?: string
+	now?: Date
+}
+
+export interface DisableOrganisationSigningCertificateInput {
+	organisationId: string
+	certificateId: string
+	now?: Date
+}
+
 export class OrgPortalRepositoryError extends Error {
 	constructor(
 		message: string,
@@ -220,6 +252,7 @@ export interface UpdateCertificateHandoffReviewVerificationInput {
 }
 
 export interface OrgPortalRepository {
+	updateOrganisationProfile: (input: UpdateOrganisationProfileInput) => Promise<OrganisationRecord>
 	findOrganisationById: (id: string) => Promise<OrganisationRecord | null>
 	findOrganisationMemberById: (id: string) => Promise<OrganisationMemberRecord | null>
 	findActiveOrganisationMemberByEmail: (email: string) => Promise<OrganisationMemberRecord | null>
@@ -256,6 +289,12 @@ export interface OrgPortalRepository {
 	findActiveOrganisationSigningCertificate: (
 		organisationId: string
 	) => Promise<OrganisationSigningCertificateRecord | null>
+	replaceOrganisationSigningCertificate: (
+		input: ReplaceOrganisationSigningCertificateInput
+	) => Promise<OrganisationSigningCertificateRecord>
+	disableOrganisationSigningCertificate: (
+		input: DisableOrganisationSigningCertificateInput
+	) => Promise<void>
 	createAuditEvent: (input: CreateAuditEventInput) => Promise<void>
 	recordOrganisationAuthAttempt: (
 		input: RecordOrganisationAuthAttemptInput
@@ -516,6 +555,36 @@ export const createPostgresOrgPortalRepository = ({
 
 	return {
 		findOrganisationById: (id) => findOrganisationById(sql, id),
+		updateOrganisationProfile: async ({
+			organisationId,
+			name,
+			registrationNumber,
+			nifCif,
+			address,
+			email,
+			phone,
+			entityType,
+			now = new Date()
+		}) => {
+			const rows = await sql`
+				update organisations
+				set
+					name = ${name},
+					registration_number = ${registrationNumber ?? null},
+					nif_cif = ${nifCif ?? null},
+					address = ${address ?? null},
+					email = ${email ?? null},
+					phone = ${phone ?? null},
+					entity_type = ${entityType},
+					updated_at = ${now.toISOString()}
+				where id = ${organisationId}
+				returning *
+			`
+			if (!rows[0]) {
+				throw new OrgPortalRepositoryError('Organisation not found.', 'not_found')
+			}
+			return organisationFromRow(rows[0])
+		},
 		findOrganisationMemberById: (id) => findMemberById(sql, id),
 		listOrganisationMembers: async (organisationId) => {
 			const rows = await sql`
@@ -977,6 +1046,76 @@ export const createPostgresOrgPortalRepository = ({
 				limit 1
 			`
 			return rows[0] ? organisationSigningCertificateFromRow(rows[0]) : null
+		},
+		replaceOrganisationSigningCertificate: async ({
+			organisationId,
+			createdByMemberId,
+			encryptedPkcs12,
+			encryptedPassphrase,
+			subject,
+			issuer,
+			serialNumber,
+			fingerprintSha256,
+			notBefore,
+			notAfter,
+			now = new Date()
+		}) =>
+			sql.begin(async (tx) => {
+				await tx`
+					update organisation_signing_certificates
+					set disabled_at = coalesce(disabled_at, ${now.toISOString()})
+					where organisation_id = ${organisationId}
+					and disabled_at is null
+				`
+
+				const rows = await tx`
+					insert into organisation_signing_certificates (
+						id,
+						organisation_id,
+						encrypted_pkcs12,
+						encrypted_passphrase,
+						subject,
+						issuer,
+						serial_number,
+						fingerprint_sha256,
+						not_before,
+						not_after,
+						created_by_member_id,
+						created_at,
+						disabled_at
+					)
+					values (
+						${randomUUID()},
+						${organisationId},
+						${encryptedPkcs12},
+						${encryptedPassphrase},
+						${subject},
+						${issuer},
+						${serialNumber},
+						${fingerprintSha256},
+						${notBefore ?? null},
+						${notAfter ?? null},
+						${createdByMemberId},
+						${now.toISOString()},
+						null
+					)
+					returning *
+				`
+
+				return organisationSigningCertificateFromRow(rows[0])
+			}),
+		disableOrganisationSigningCertificate: async ({
+			organisationId,
+			certificateId,
+			now = new Date()
+		}) => {
+			await sql`
+				update organisation_signing_certificates
+				set disabled_at = coalesce(disabled_at, ${now.toISOString()})
+				where organisation_id = ${organisationId}
+				and id = ${certificateId}
+				and disabled_at is null
+			`
 		},
 
 		createAuditEvent: async ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.8
         version: 2.4.8
+      '@primer-paso/db':
+        specifier: workspace:*
+        version: link:packages/db
+      '@primer-paso/signing-client':
+        specifier: workspace:*
+        version: link:packages/signing-client
       '@types/node':
         specifier: ^24
         version: 24.12.2

--- a/scripts/add-org-signing-certificate.ts
+++ b/scripts/add-org-signing-certificate.ts
@@ -3,13 +3,7 @@
 import { readFile } from 'node:fs/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { createInterface } from 'node:readline/promises'
-/**
- * Adapt this import if your DB package exports a different helper.
- *
- * Expected shape:
- *   sql`...`
- */
-import { sql } from '@primer-paso/db'
+import { createPostgresOrgPortalRepository } from '@primer-paso/db'
 import { inspectSigningCertificate } from '@primer-paso/signing-client'
 import {
 	encryptSigningSecret,
@@ -24,9 +18,17 @@ type Args = {
 
 const args = parseArgs(process.argv.slice(2))
 
+const databaseUrl = process.env.PRIVATE_DATABASE_URL?.trim() || process.env.DATABASE_URL?.trim()
+if (!databaseUrl) {
+	console.error('Set PRIVATE_DATABASE_URL or DATABASE_URL before running this script.')
+	process.exit(1)
+}
+
 const signerUrl = requiredEnv('PRIVATE_PDF_SIGNER_URL')
 const signerToken = requiredEnv('PRIVATE_PDF_SIGNER_TOKEN')
 const encryptionKey = requiredEnv('PRIVATE_SIGNING_CERT_ENCRYPTION_KEY')
+
+const repository = createPostgresOrgPortalRepository({ databaseUrl })
 
 const certBytes = await readFile(args.certPath)
 const passphrase = await promptHidden('Certificate password: ')
@@ -41,48 +43,22 @@ const metadata = await inspectSigningCertificate({
 const encryptedPkcs12 = encryptSigningSecret(certBytes, encryptionKey)
 const encryptedPassphrase = encryptSigningText(passphrase, encryptionKey)
 
-await sql`
-  insert into organisation_signing_certificates (
-    organisation_id,
-    encrypted_pkcs12,
-    encrypted_passphrase,
-    subject,
-    issuer,
-    serial_number,
-    fingerprint_sha256,
-    not_before,
-    not_after,
-    created_by_member_id
-  )
-  values (
-    ${args.organisationId},
-    ${encryptedPkcs12},
-    ${encryptedPassphrase},
-    ${metadata.signerSubject},
-    ${metadata.signerIssuer},
-    ${metadata.certificateSerialNumber},
-    ${metadata.certificateFingerprintSha256},
-    ${metadata.notBefore},
-    ${metadata.notAfter},
-    ${args.createdByMemberId}
-  )
-  on conflict (organisation_id)
-  where disabled_at is null
-  do update set
-    encrypted_pkcs12 = excluded.encrypted_pkcs12,
-    encrypted_passphrase = excluded.encrypted_passphrase,
-    subject = excluded.subject,
-    issuer = excluded.issuer,
-    serial_number = excluded.serial_number,
-    fingerprint_sha256 = excluded.fingerprint_sha256,
-    not_before = excluded.not_before,
-    not_after = excluded.not_after,
-    created_by_member_id = excluded.created_by_member_id,
-    created_at = now()
-`
+const signingCertificate = await repository.replaceOrganisationSigningCertificate({
+	organisationId: args.organisationId,
+	createdByMemberId: args.createdByMemberId,
+	encryptedPkcs12,
+	encryptedPassphrase,
+	subject: metadata.signerSubject,
+	issuer: metadata.signerIssuer,
+	serialNumber: metadata.certificateSerialNumber,
+	fingerprintSha256: metadata.certificateFingerprintSha256,
+	notBefore: metadata.notBefore?.toISOString(),
+	notAfter: metadata.notAfter?.toISOString()
+})
 
 console.log('Stored organisation signing certificate')
 console.log(`Organisation: ${args.organisationId}`)
+console.log(`Certificate row id: ${signingCertificate.id}`)
 console.log(`Subject: ${metadata.signerSubject}`)
 console.log(`Issuer: ${metadata.signerIssuer}`)
 console.log(`Serial: ${metadata.certificateSerialNumber}`)

--- a/services/pdf-signer/src/pdf_signer/signing.py
+++ b/services/pdf-signer/src/pdf_signer/signing.py
@@ -85,6 +85,16 @@ def _certificate_validity_time(cert: Any, field_name: str) -> datetime | None:
     return _normalise_cert_time(value)
 
 
+def _validate_certificate_is_current(cert: Any) -> None:
+    now = datetime.now(UTC)
+    not_before = _certificate_validity_time(cert, "not_before")
+    not_after = _certificate_validity_time(cert, "not_after")
+    if not_before is not None and not_before > now:
+        raise SigningInputError("signing certificate is not valid yet")
+    if not_after is not None and not_after <= now:
+        raise SigningInputError("signing certificate has expired")
+
+
 def inspect_certificate(
     request: InspectCertificateRequest,
 ) -> InspectCertificateResponse:
@@ -97,7 +107,7 @@ def inspect_certificate(
     signing_cert = signer.signing_cert
     if signing_cert is None:
         raise SigningInputError("PKCS#12 certificate has no signing certificate")
-
+    _validate_certificate_is_current(signing_cert)
     return InspectCertificateResponse(
         signer_subject=signing_cert.subject.human_friendly,
         signer_issuer=signing_cert.issuer.human_friendly,
@@ -155,6 +165,7 @@ def sign_pdf(request: SignPdfRequest) -> SignPdfResponse:
     signing_cert = signer.signing_cert
     if signing_cert is None:
         raise SigningInputError("PKCS#12 certificate has no signing certificate")
+    _validate_certificate_is_current(signing_cert)
     return SignPdfResponse(
         signed_pdf_base64=base64.b64encode(signed_pdf).decode("ascii"),
         signer_subject=signing_cert.subject.human_friendly,

--- a/supabase/snippets/Untitled query 657.sql
+++ b/supabase/snippets/Untitled query 657.sql
@@ -1,0 +1,5 @@
+select created_at, event_data
+from audit_events
+where event_type = 'organisation.signing_certificate_replace_failed'
+order by created_at desc
+limit 5;


### PR DESCRIPTION
## What changed?

Previously, org details were hardcoded. Now they can be updated by the admin.

## Risk level

- [ ] Low: copy, docs, styling, tests only
- [ ] Medium: app logic, validation, routing, dependencies
- [x] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


