### PR TITLE
feat: remove short handover reference code

### DIFF
--- a/apps/org-portal/src/lib/server/handoff-token-input.test.ts
+++ b/apps/org-portal/src/lib/server/handoff-token-input.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { extractHandoffToken, looksLikeReferenceCode } from './handoff-token-input'
+
+describe('extractHandoffToken', () => {
+	it('returns token query param from a full handoff URL', () => {
+		const token = 'abc-def_ghi'
+		const url = `https://org.primerpaso.org/handoff?token=${encodeURIComponent(token)}`
+		expect(extractHandoffToken(url)).toBe(token)
+	})
+
+	it('returns raw string when input is not a URL', () => {
+		const raw = 'xYz123-_'
+		expect(extractHandoffToken(raw)).toBe(raw)
+	})
+
+	it('returns empty for whitespace-only', () => {
+		expect(extractHandoffToken('   ')).toBe('')
+	})
+
+	it('returns empty when URL has no token param', () => {
+		expect(extractHandoffToken('https://org.primerpaso.org/handoff')).toBe('')
+	})
+
+	it('does not read ref or reference query params', () => {
+		const url = 'https://org.primerpaso.org/handoff?ref=ABCD-1234-EF&referenceCode=ABCD-1234-EF'
+		expect(extractHandoffToken(url)).toBe('')
+	})
+})
+
+describe('looksLikeReferenceCode', () => {
+	it('matches support-style reference codes', () => {
+		expect(looksLikeReferenceCode('ABCD-1234-EF')).toBe(true)
+		expect(looksLikeReferenceCode('abcd 1234 ef')).toBe(true)
+	})
+
+	it('does not match typical opaque handoff tokens', () => {
+		expect(
+			looksLikeReferenceCode(
+				'8K3nF9pQx2mL5vR1tY7wZ4bC6dE0gH2jJ4kM8nPqRsTuVwXyZaBcDeFgHiJkLmNoPqRsTuVw'
+			)
+		).toBe(false)
+	})
+})

--- a/apps/org-portal/src/lib/server/handoff-token-input.ts
+++ b/apps/org-portal/src/lib/server/handoff-token-input.ts
@@ -1,0 +1,19 @@
+/** Parse pasted org-portal handoff input: full URL with ?token=... or raw token only. */
+export const extractHandoffToken = (value: string) => {
+	const trimmed = value.trim()
+	if (!trimmed) return ''
+
+	try {
+		const url = new URL(trimmed)
+		return url.searchParams.get('token')?.trim() ?? ''
+	} catch {
+		return trimmed
+	}
+}
+
+// Generated handoff tokens are 32 random bytes encoded as base64url, so they are
+// much longer than support reference codes. This guard only catches likely
+// support-code input pasted into the secure-link field.
+/** UX guard: human-readable support reference (not an access credential). */
+export const looksLikeReferenceCode = (value: string) =>
+	/^[A-Z0-9]{4}[-\s]?[A-Z0-9]{4}[-\s]?[A-Z0-9]{2}$/i.test(value.trim())

--- a/apps/org-portal/src/routes/handoff/+page.server.ts
+++ b/apps/org-portal/src/routes/handoff/+page.server.ts
@@ -1,26 +1,26 @@
 import { redirect } from '@sveltejs/kit'
 import { requirePermission, setPendingHandoffToken } from '$lib/server/auth'
+import { extractHandoffToken, looksLikeReferenceCode } from '$lib/server/handoff-token-input'
 import type { PageServerLoad } from './$types'
 
-const extractToken = (value: string) => {
-	const trimmed = value.trim()
-	if (!trimmed) return ''
-
-	try {
-		const url = new URL(trimmed)
-		return url.searchParams.get('token')?.trim() ?? ''
-	} catch {
-		return trimmed
-	}
-}
-
 export const load: PageServerLoad = ({ cookies, locals, url }) => {
-	const token = extractToken(url.searchParams.get('token') ?? '')
+	const rawTokenParam = url.searchParams.get('token')
+	const hasTokenParam = url.searchParams.has('token')
+	const token = extractHandoffToken(rawTokenParam ?? '')
 
 	if (!token) {
 		return {
 			hasToken: false,
-			signedIn: Boolean(locals.session)
+			signedIn: Boolean(locals.session),
+			error: hasTokenParam ? 'missing_token' : undefined
+		}
+	}
+
+	if (looksLikeReferenceCode(token)) {
+		return {
+			hasToken: false,
+			signedIn: Boolean(locals.session),
+			error: 'reference_code_not_supported'
 		}
 	}
 

--- a/apps/org-portal/src/routes/handoff/+page.svelte
+++ b/apps/org-portal/src/routes/handoff/+page.svelte
@@ -21,29 +21,41 @@ let { data } = $props()
 		<CardHeader>
 			<CardTitle>
 				{#if data.hasToken}
-					Referencia de borrador recibida
+					Acceso al borrador en curso
 				{:else}
-					Sin referencia de borrador
+					Abrir borrador de certificado
 				{/if}
 			</CardTitle>
 			<CardDescription>
 				{#if data.hasToken}
 					Inicia sesión como persona autorizada de la organización para abrir el borrador.
 				{:else}
-					Abre esta página desde un código QR de Primer Paso o pega el enlace o código del borrador.
+					Abre esta página desde un código QR de Primer Paso o pega el enlace seguro del borrador.
 				{/if}
 			</CardDescription>
 		</CardHeader>
 		{#if !data.hasToken}
 			<CardContent>
+				{#if data.error === 'reference_code_not_supported'}
+					<div class="panel-subtle" role="alert">
+						<p class="text-pretty">
+							Ese código es solo una referencia. Para abrir el borrador necesitas escanear el QR o
+							pegar el enlace seguro completo.
+						</p>
+					</div>
+				{:else if data.error === 'missing_token'}
+					<div class="panel-subtle" role="alert">
+						<p class="text-pretty">Pega el enlace seguro completo del borrador.</p>
+					</div>
+				{/if}
 				<form method="GET" action="/handoff" class="stack">
 					<div class="form-field">
-						<Label for="token">Enlace o código del borrador</Label>
+						<Label for="token">Enlace seguro del borrador</Label>
 						<Input
 							id="token"
 							name="token"
 							autocomplete="off"
-							placeholder="Pega un enlace o código"
+							placeholder="Pega el enlace seguro del borrador"
 						/>
 					</div>
 					<div class="actions"><Button type="submit">Abrir borrador</Button></div>

--- a/apps/public/src/routes/[lang=lang]/certificate/handoff/+page.svelte
+++ b/apps/public/src/routes/[lang=lang]/certificate/handoff/+page.svelte
@@ -3,6 +3,29 @@ import { Button } from '@primer-paso/ui/button'
 
 let { data } = $props()
 
+let copied = $state(false)
+let copyFailed = $state(false)
+
+/* Clipboard: UI Button spreads rest props onto a native button, so onclick is forwarded. */
+async function copyOrgHandoffUrl() {
+	copyFailed = false
+
+	if (!navigator.clipboard?.writeText) {
+		copyFailed = true
+		return
+	}
+
+	try {
+		await navigator.clipboard.writeText(data.orgHandoffUrl)
+		copied = true
+		setTimeout(() => {
+			copied = false
+		}, 2500)
+	} catch {
+		copyFailed = true
+	}
+}
+
 const expiresAt = $derived(
 	new Date(data.expiresAt).toLocaleString(data.locale ?? 'es', {
 		timeZone: 'Europe/Madrid'
@@ -25,6 +48,7 @@ const expiresAt = $derived(
 				The certificate draft has been saved for organisation review. This is still not an issued
 				certificate.
 			</p>
+			<p class="lead-text">Show this QR code or secure link to the organisation.</p>
 			<p class="hint">
 				The organisation must open the handoff, check the information, decide what it can certify,
 				and issue the final document.
@@ -32,16 +56,10 @@ const expiresAt = $derived(
 		</div>
 
 		<section class="panel section-block">
-			<h2 class="section-title">Reference code</h2>
-			<p class="lead-text">{data.referenceCode}</p>
-			<p class="hint">Expires: {expiresAt}</p>
-		</section>
-
-		<section class="panel section-block">
 			<h2 class="section-title">QR code</h2>
 			<p class="hint">
-				Show this QR code to the organisation. It contains a handoff link, not the full certificate
-				information.
+				This QR code opens the secure organisation handoff link. It does not contain the full
+				certificate information.
 			</p>
 			<img
 				src={data.qrHref}
@@ -53,12 +71,35 @@ const expiresAt = $derived(
 		</section>
 
 		<section class="panel-subtle section-block">
-			<h2 class="section-title">Organisation link</h2>
+			<h2 class="section-title">Organisation secure link</h2>
 			<p class="hint">
-				This link is for authorised organisation users. Show the QR code or reference code to the
-				organisation rather than opening it yourself.
+				If the QR code cannot be scanned, the organisation can copy or type this secure link. This
+				link is for authorised organisation users only. Do not open it yourself instead of handing
+				it to the organisation.
 			</p>
 			<p class="break-all">{data.orgHandoffUrl}</p>
+			<div class="actions" style="margin-top: 0.75rem">
+				<Button type="button" variant="outline" size="sm" onclick={copyOrgHandoffUrl}>
+					Copy secure link
+				</Button>
+			</div>
+			{#if copied}
+				<p class="hint" role="status" aria-live="polite">Link copied.</p>
+			{/if}
+			{#if copyFailed}
+				<p class="hint" role="status" aria-live="polite">
+					Copy did not work. You can select the link text above instead.
+				</p>
+			{/if}
+		</section>
+
+		<section class="panel section-block">
+			<h2 class="section-title">Reference code</h2>
+			<p class="hint">
+				Use this code only if support staff need to identify this handoff. It cannot open the draft.
+			</p>
+			<p class="lead-text">{data.referenceCode}</p>
+			<p class="hint">Expires: {expiresAt}</p>
 		</section>
 
 		<div class="actions"><Button href={data.backHref} variant="outline">Back</Button></div>

--- a/apps/public/src/routes/[lang=lang]/certificate/handoff/handoff-page-content.test.ts
+++ b/apps/public/src/routes/[lang=lang]/certificate/handoff/handoff-page-content.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pageSvelte = readFileSync(join(here, '+page.svelte'), 'utf8')
+const pageServer = readFileSync(join(here, '+page.server.ts'), 'utf8')
+
+describe('public certificate handoff page', () => {
+	it('positions reference code as support-only, not as an opener', () => {
+		expect(pageSvelte).toContain(
+			'Use this code only if support staff need to identify this handoff'
+		)
+		expect(pageSvelte).toContain('It cannot open the draft')
+		expect(pageSvelte).not.toContain('Show the QR code or reference code')
+		expect(pageSvelte).toContain('Show this QR code or secure link to the organisation')
+	})
+
+	it('describes QR and secure link access without reference-code fallback', () => {
+		expect(pageSvelte).toContain('This QR code opens the secure organisation handoff link')
+		expect(pageSvelte).toContain('copy or type this secure link')
+		expect(pageSvelte).toContain('data.orgHandoffUrl')
+		expect(pageSvelte).toContain('Copy secure link')
+		expect(pageSvelte).toContain('Link copied.')
+		expect(pageSvelte).toContain('aria-live="polite"')
+	})
+
+	it('builds org handoff and QR URLs from the opaque token', () => {
+		expect(pageServer).toContain("url.searchParams.set('token', token)")
+		expect(pageServer).toContain('/handoff')
+		expect(pageServer).toContain('qr.svg')
+		expect(pageServer).toContain('encodeURIComponent(token)')
+	})
+})

--- a/docs/adr/014-token-based-certificate-handoff.md
+++ b/docs/adr/014-token-based-certificate-handoff.md
@@ -18,7 +18,13 @@ QR codes are useful for in-person handoff, but storing the full sensitive payloa
 
 ## Decision
 
-Certificate handoff QR codes will contain a random handoff URL or reference token, not the full certificate data.
+Certificate handoff QR codes will encode the canonical organisation handoff URL carrying a high-entropy opaque token, not the full certificate data.
+
+The QR code and visible organisation handoff link encode the same high-entropy opaque token URL.
+
+The human-readable reference code is not an access credential and must not be usable to open a certificate draft. It exists only as a support identifier.
+
+We are intentionally not implementing reference-code lookup in the pilot because it would create a lower-entropy second access path requiring additional rate limiting, enumeration protection, audit review, support procedures, and ongoing maintenance.
 
 The certificate draft data will be stored server-side with an expiry time and accessed only through the organisation portal after authentication and authorisation checks.
 

--- a/docs/deployment-certificate-pilot.md
+++ b/docs/deployment-certificate-pilot.md
@@ -4,6 +4,8 @@ This note records the minimum deployment setup for testing the certificate draft
 
 It covers deployment only. Certificate issue, email login, audit viewing, member management, retention jobs, rate limiting, and tenant isolation hardening are later production-hardening work.
 
+Certificate handoff access is QR/link-only. The organisation must scan the QR code or use the secure handoff link. The reference code is only a support identifier and cannot open a draft.
+
 ## Deployment shape
 
 Deploy the public service and organisation portal as separate sites:


### PR DESCRIPTION
## What changed?

Removed short handover reference code, that wasn't part of the flow for getting the handover. Instead use it just as a way for the work to confirm which handover they are looking at.

## Risk level

- [ ] Low: copy, docs, styling, tests only
- [x] Medium: app logic, validation, routing, dependencies
- [ ] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


