### PR TITLE
feat: add docker setup for pdf signing service

### DIFF
--- a/docs/deployment-certificate-pilot.md
+++ b/docs/deployment-certificate-pilot.md
@@ -39,6 +39,59 @@ Apply migrations before enabling handoff creation:
 pnpm db:migrate
 ```
 
+## PDF signer service
+
+Certificate issue requires the internal PDF signer service.
+
+The signer is a separate containerised service, built from:
+
+```txt
+services/pdf-signer/Dockerfile
+```
+
+Build locally from the repository root:
+
+```sh
+pnpm pdf-signer:docker:build
+```
+
+Run locally:
+
+```sh
+pnpm pdf-signer:docker:run
+```
+
+The container exposes port `8080` and requires:
+
+```txt
+PDF_SIGNER_TOKEN
+```
+
+The organisation portal must be configured with:
+
+```txt
+PRIVATE_PDF_SIGNER_URL=https://<pdf-signer-service>
+PRIVATE_PDF_SIGNER_TOKEN=<the bearer token configured as PDF_SIGNER_TOKEN on the signer>
+PRIVATE_SIGNING_CERT_ENCRYPTION_KEY=<base64 32-byte key>
+```
+
+Generate the signing-certificate encryption key with:
+
+```sh
+openssl rand -base64 32
+```
+
+The PDF signer should be deployed as an internal service where the hosting
+platform supports private networking. If it must be exposed over HTTPS, it must
+remain protected by the bearer token and by any available platform-level network
+restrictions.
+
+Health check:
+
+```sh
+curl https://<pdf-signer-service>/healthz
+```
+
 Applied migrations are tracked in:
 
 ```txt

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 		"org-signing:add-certificate:local": "node --env-file=.env --import tsx scripts/add-org-signing-certificate.ts",
 		"org-signing:add-certificate:production": "node --env-file=.env.netlify.production --import tsx scripts/add-org-signing-certificate.ts",
 		"signing:test-pdf": "node --env-file=.env scripts/test-pdf-signing-service.mjs",
+		"pdf-signer:docker:build": "docker build -t primer-paso-pdf-signer:local services/pdf-signer",
+		"pdf-signer:docker:run": "docker run --rm --name primer-paso-pdf-signer -p 8080:8080 --env PDF_SIGNER_TOKEN=dev-pdf-signer-token primer-paso-pdf-signer:local",
 		"dev": "pnpm --filter @primer-paso/public dev",
 		"dev:public": "pnpm --filter @primer-paso/public dev",
 		"dev:org": "pnpm --filter @primer-paso/org-portal dev",

--- a/services/pdf-signer/.dockerignore
+++ b/services/pdf-signer/.dockerignore
@@ -1,0 +1,11 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+dist/
+build/
+*.egg-info/
+.git/
+.github/
+.pre-commit-config.yaml

--- a/services/pdf-signer/Dockerfile
+++ b/services/pdf-signer/Dockerfile
@@ -1,0 +1,43 @@
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.0 /uv /uvx /bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+	UV_LINK_MODE=copy \
+	UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock uv.toml README.md ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+	uv sync --locked --no-dev --no-install-project --no-editable
+
+COPY src ./src
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+	uv sync --locked --no-dev --no-editable
+
+
+FROM python:3.12-slim AS runtime
+
+ENV PATH="/app/.venv/bin:$PATH" \
+	PYTHONUNBUFFERED=1 \
+	PDF_SIGNER_HOST=0.0.0.0 \
+	PDF_SIGNER_PORT=8080
+
+WORKDIR /app
+
+RUN groupadd --system --gid 10001 app \
+	&& useradd --system --uid 10001 --gid app --home-dir /app app
+
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+
+USER app
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+	CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).read()" || exit 1
+
+CMD ["pdf-signer"]

--- a/services/pdf-signer/README.md
+++ b/services/pdf-signer/README.md
@@ -30,6 +30,32 @@ PDF_SIGNER_MAX_PDF_BYTES="10485760"
 PDF_SIGNER_MAX_PKCS12_BYTES="2097152"
 ```
 
+## Docker
+
+Build from the repository root:
+
+```bash
+pnpm pdf-signer:docker:build
+```
+
+Run locally:
+
+```bash
+pnpm pdf-signer:docker:run
+```
+
+Or run directly from this directory:
+
+```bash
+docker build -t primer-paso-pdf-signer:local .
+docker run --rm \
+	-p 8080:8080 \
+	--env PDF_SIGNER_TOKEN=dev-pdf-signer-token \
+	primer-paso-pdf-signer:local
+```
+
+The container listens on port 8080.
+
 ## Local development
 
 ```bash
@@ -85,5 +111,26 @@ Response:
   "certificate_serial_number": "...",
   "certificate_fingerprint_sha256": "..."
 }
+```
+
+## Organisation portal integration
+
+The organisation portal calls this service over HTTP. Configure the portal with:
+
+```bash
+PRIVATE_PDF_SIGNER_URL="http://127.0.0.1:8080" PRIVATE_PDF_SIGNER_TOKEN="dev-pdf-signer-token"
+```
+
+For production, `PRIVATE_PDF_SIGNER_TOKEN` must match the signer's
+`PDF_SIGNER_TOKEN` bearer token.
+
+The signer should be deployed as an internal service where possible. If it must
+be reachable over public HTTPS, keep OpenAPI docs disabled, use a high-entropy
+bearer token, and restrict network access at the hosting layer where available.
+
+Health check:
+
+```bash
+curl http://127.0.0.1:8080/healthz
 ```
 


### PR DESCRIPTION
## What changed?

Adds Dockerfile for deploying Python pdf signer as a standalone service.

## Risk level

- [ ] Low: copy, docs, styling, tests only
- [ ] Medium: app logic, validation, routing, dependencies
- [x] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


