### PR TITLE
feat: allow org members to modify vulnerability certificates

### DIFF
--- a/apps/org-portal/src/lib/ModifiedNote.svelte
+++ b/apps/org-portal/src/lib/ModifiedNote.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+let { original } = $props<{
+	original: string
+}>()
+</script>
+
+<p class="modified-note">Modificado. Original: {original}</p>
+
+<style>
+.modified-note {
+	margin-top: 0.25rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--color-warning-text, #92400e);
+}
+</style>

--- a/apps/org-portal/src/lib/ReviewInputField.svelte
+++ b/apps/org-portal/src/lib/ReviewInputField.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+import ModifiedNote from './ModifiedNote.svelte'
+
+let {
+	label,
+	name,
+	type = 'text',
+	value = $bindable(),
+	readonly,
+	modified,
+	original
+} = $props<{
+	label: string
+	name: string
+	type?: string
+	value: string | undefined
+	readonly: boolean
+	modified: boolean
+	original: string
+}>()
+</script>
+
+<div class="form-field">
+	<label for={name}>{label}</label>
+	<input id={name} {name} {type} bind:value {readonly} data-modified={modified}>
+	{#if modified}
+		<ModifiedNote {original} />
+	{/if}
+</div>
+
+<style>
+input[data-modified='true'],
+input[readonly][data-modified='true'] {
+	border-color: var(--color-warning, #b7791f);
+	background: color-mix(in srgb, var(--color-warning, #b7791f) 8%, transparent);
+}
+
+input[readonly] {
+	cursor: default;
+}
+</style>

--- a/apps/org-portal/src/lib/ReviewInputField.svelte
+++ b/apps/org-portal/src/lib/ReviewInputField.svelte
@@ -8,7 +8,8 @@ let {
 	value = $bindable(),
 	readonly,
 	modified,
-	original
+	original,
+	oninput: oninputProp
 } = $props<{
 	label: string
 	name: string
@@ -17,20 +18,33 @@ let {
 	readonly: boolean
 	modified: boolean
 	original: string
+	oninput?: (event: Event & { currentTarget: HTMLInputElement }) => void
 }>()
 </script>
 
 <div class="form-field">
 	<label for={name}>{label}</label>
-	<input id={name} {name} {type} bind:value {readonly} data-modified={modified}>
+	{#if oninputProp}
+		<input
+			id={name}
+			{name}
+			{type}
+			value={value ?? ''}
+			{readonly}
+			data-modified={modified}
+			oninput={oninputProp}
+		>
+	{:else}
+		<input id={name} {name} {type} bind:value {readonly} data-modified={modified}>
+	{/if}
 	{#if modified}
 		<ModifiedNote {original} />
 	{/if}
 </div>
 
 <style>
-input[data-modified='true'],
-input[readonly][data-modified='true'] {
+input[data-modified="true"],
+input[readonly][data-modified="true"] {
 	border-color: var(--color-warning, #b7791f);
 	background: color-mix(in srgb, var(--color-warning, #b7791f) 8%, transparent);
 }

--- a/apps/org-portal/src/lib/certificate-review-fields.ts
+++ b/apps/org-portal/src/lib/certificate-review-fields.ts
@@ -3,25 +3,11 @@ import {
 	type CertificateDraftReviewFieldPath
 } from '@primer-paso/certificate'
 
-export type CertificateReviewFieldSection = 'identity' | 'contact' | 'location' | 'vulnerability'
-
-export interface CertificateReviewFieldUi {
-	label: string
-	section: CertificateReviewFieldSection
-	widget: 'text' | 'email' | 'date' | 'select' | 'checkbox-group'
-}
+export type ReviewFieldSection = 'identity' | 'contact' | 'location' | 'vulnerability'
 
 export const certificateReviewFieldUi = {
-	'userData.identity.givenNames': {
-		label: 'Nombres',
-		section: 'identity',
-		widget: 'text'
-	},
-	'userData.identity.familyNames': {
-		label: 'Apellidos',
-		section: 'identity',
-		widget: 'text'
-	},
+	'userData.identity.givenNames': { label: 'Nombres', section: 'identity', widget: 'text' },
+	'userData.identity.familyNames': { label: 'Apellidos', section: 'identity', widget: 'text' },
 	'userData.identity.documentType': {
 		label: 'Tipo de documento',
 		section: 'identity',
@@ -37,52 +23,27 @@ export const certificateReviewFieldUi = {
 		section: 'identity',
 		widget: 'date'
 	},
-	'userData.identity.nationality': {
-		label: 'Nacionalidad',
-		section: 'identity',
-		widget: 'text'
-	},
-	'userData.contact.email': {
-		label: 'Correo electrónico',
-		section: 'contact',
-		widget: 'email'
-	},
-	'userData.contact.phone': {
-		label: 'Teléfono',
-		section: 'contact',
-		widget: 'text'
-	},
-	'userData.location.addressLine1': {
-		label: 'Dirección',
-		section: 'location',
-		widget: 'text'
-	},
+	'userData.identity.nationality': { label: 'Nacionalidad', section: 'identity', widget: 'text' },
+	'userData.contact.email': { label: 'Correo electrónico', section: 'contact', widget: 'email' },
+	'userData.contact.phone': { label: 'Teléfono', section: 'contact', widget: 'text' },
+	'userData.location.addressLine1': { label: 'Dirección', section: 'location', widget: 'text' },
 	'userData.location.addressLine2': {
 		label: 'Dirección, línea 2',
 		section: 'location',
 		widget: 'text'
 	},
-	'userData.location.municipality': {
-		label: 'Municipio',
-		section: 'location',
-		widget: 'text'
-	},
-	'userData.location.province': {
-		label: 'Provincia',
-		section: 'location',
-		widget: 'text'
-	},
-	'userData.location.postalCode': {
-		label: 'Código postal',
-		section: 'location',
-		widget: 'text'
-	},
+	'userData.location.municipality': { label: 'Municipio', section: 'location', widget: 'text' },
+	'userData.location.province': { label: 'Provincia', section: 'location', widget: 'text' },
+	'userData.location.postalCode': { label: 'Código postal', section: 'location', widget: 'text' },
 	'userData.vulnerability.reasons': {
 		label: 'Circunstancias de vulnerabilidad',
 		section: 'vulnerability',
 		widget: 'checkbox-group'
 	}
-} as const satisfies Record<CertificateDraftReviewFieldPath, CertificateReviewFieldUi>
+} as const satisfies Record<
+	CertificateDraftReviewFieldPath,
+	{ label: string; section: ReviewFieldSection; widget: string }
+>
 
 export const certificateReviewFields = CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => ({
 	...field,

--- a/apps/org-portal/src/lib/certificate-review-fields.ts
+++ b/apps/org-portal/src/lib/certificate-review-fields.ts
@@ -1,0 +1,90 @@
+import {
+	CERTIFICATE_DRAFT_REVIEW_FIELDS,
+	type CertificateDraftReviewFieldPath
+} from '@primer-paso/certificate'
+
+export type CertificateReviewFieldSection = 'identity' | 'contact' | 'location' | 'vulnerability'
+
+export interface CertificateReviewFieldUi {
+	label: string
+	section: CertificateReviewFieldSection
+	widget: 'text' | 'email' | 'date' | 'select' | 'checkbox-group'
+}
+
+export const certificateReviewFieldUi = {
+	'userData.identity.givenNames': {
+		label: 'Nombres',
+		section: 'identity',
+		widget: 'text'
+	},
+	'userData.identity.familyNames': {
+		label: 'Apellidos',
+		section: 'identity',
+		widget: 'text'
+	},
+	'userData.identity.documentType': {
+		label: 'Tipo de documento',
+		section: 'identity',
+		widget: 'select'
+	},
+	'userData.identity.documentNumber': {
+		label: 'Número de documento',
+		section: 'identity',
+		widget: 'text'
+	},
+	'userData.identity.dateOfBirth': {
+		label: 'Fecha de nacimiento',
+		section: 'identity',
+		widget: 'date'
+	},
+	'userData.identity.nationality': {
+		label: 'Nacionalidad',
+		section: 'identity',
+		widget: 'text'
+	},
+	'userData.contact.email': {
+		label: 'Correo electrónico',
+		section: 'contact',
+		widget: 'email'
+	},
+	'userData.contact.phone': {
+		label: 'Teléfono',
+		section: 'contact',
+		widget: 'text'
+	},
+	'userData.location.addressLine1': {
+		label: 'Dirección',
+		section: 'location',
+		widget: 'text'
+	},
+	'userData.location.addressLine2': {
+		label: 'Dirección, línea 2',
+		section: 'location',
+		widget: 'text'
+	},
+	'userData.location.municipality': {
+		label: 'Municipio',
+		section: 'location',
+		widget: 'text'
+	},
+	'userData.location.province': {
+		label: 'Provincia',
+		section: 'location',
+		widget: 'text'
+	},
+	'userData.location.postalCode': {
+		label: 'Código postal',
+		section: 'location',
+		widget: 'text'
+	},
+	'userData.vulnerability.reasons': {
+		label: 'Circunstancias de vulnerabilidad',
+		section: 'vulnerability',
+		widget: 'checkbox-group'
+	}
+} as const satisfies Record<CertificateDraftReviewFieldPath, CertificateReviewFieldUi>
+
+export const certificateReviewFields = CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => ({
+	...field,
+	...certificateReviewFieldUi[field.path]
+}))

--- a/apps/org-portal/src/lib/labels.ts
+++ b/apps/org-portal/src/lib/labels.ts
@@ -55,6 +55,7 @@ export const auditEventLabel = (eventType: string) =>
 		'handoff.open_failed': 'Error al abrir borrador',
 		'handoff.invalid_draft': 'Borrador no válido',
 		'review.updated': 'Confirmaciones guardadas',
+		'certificate.review.corrected': 'Datos revisados corregidos',
 		'review.ready_to_issue': 'Revisión marcada como lista para emitir',
 		'certificate.issued': 'Certificado emitido',
 		'certificate.issue_failed': 'Error al emitir certificado',

--- a/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
@@ -1,17 +1,29 @@
 import {
+	type CertificateDraft,
 	generateVulnerabilityCertificatePdf,
 	parseCertificateDraft,
-	parseCertificateIssueRequest
+	parseCertificateIssueRequest,
+	VULNERABILITY_REASON_VALUES,
+	validateCertificateDraft
 } from '@primer-paso/certificate'
-import type { VerificationReview } from '@primer-paso/db'
+import type { CertificateCorrectionType, VerificationReview } from '@primer-paso/db'
 import { signPdfWithOrganisationCertificate } from '@primer-paso/signing-client'
 import { error, fail, redirect } from '@sveltejs/kit'
 import { env } from '$env/dynamic/private'
+import { vulnerabilityReasonLabel } from '$lib/labels'
 import { writeAuditEvent } from '$lib/server/audit'
 import { requirePermission } from '$lib/server/auth'
 import { getOrgPortalRepository } from '$lib/server/repository'
 import { decryptSigningSecret, decryptSigningText } from '$lib/server/signing-secret-crypto'
 import type { Actions, PageServerLoad } from './$types'
+
+const CORRECTION_TYPES = [
+	'typo',
+	'confirmed_with_applicant',
+	'document_verified',
+	'standardised_format',
+	'other'
+] as const satisfies readonly CertificateCorrectionType[]
 
 const parseVerification = (formData: FormData) => ({
 	passportOrIdentityDocumentChecked: formData.get('passportOrIdentityDocumentChecked') === 'yes',
@@ -27,9 +39,131 @@ const verificationComplete = (verification: ReturnType<typeof parseVerification>
 const storedVerificationComplete = (verification: VerificationReview | undefined) =>
 	Boolean(
 		verification?.passportOrIdentityDocumentChecked &&
-			verification.userInformationConfirmed &&
-			verification.vulnerabilityInformationReviewed
+			verification?.userInformationConfirmed &&
+			verification?.vulnerabilityInformationReviewed
 	)
+
+const getString = (formData: FormData, name: string) => String(formData.get(name) ?? '').trim()
+
+const getOptionalString = (formData: FormData, name: string) => {
+	const value = getString(formData, name)
+	return value.length > 0 ? value : undefined
+}
+
+const getStringList = (formData: FormData, name: string) =>
+	formData.getAll(name).map(String).filter(Boolean)
+
+const getCorrectionType = (formData: FormData): CertificateCorrectionType => {
+	const value = String(formData.get('correctionType') ?? 'confirmed_with_applicant')
+	return CORRECTION_TYPES.includes(value as CertificateCorrectionType)
+		? (value as CertificateCorrectionType)
+		: 'confirmed_with_applicant'
+}
+
+const withReviewedDataFromForm = (
+	draft: CertificateDraft,
+	formData: FormData
+): CertificateDraft => ({
+	...draft,
+	userData: {
+		...draft.userData,
+		identity: {
+			...draft.userData.identity,
+			givenNames: getString(formData, 'givenNames'),
+			familyNames: getString(formData, 'familyNames'),
+			documentType: getString(
+				formData,
+				'documentType'
+			) as CertificateDraft['userData']['identity']['documentType'],
+			documentNumber: getString(formData, 'documentNumber'),
+			dateOfBirth: getOptionalString(formData, 'dateOfBirth'),
+			nationality: getOptionalString(formData, 'nationality')
+		},
+		contact: {
+			...draft.userData.contact,
+			email: getString(formData, 'email'),
+			phone: getOptionalString(formData, 'phone')
+		},
+		location: {
+			...draft.userData.location,
+			addressLine1: getString(formData, 'addressLine1'),
+			addressLine2: getOptionalString(formData, 'addressLine2'),
+			municipality: getString(formData, 'municipality'),
+			province: getString(formData, 'province'),
+			postalCode: getOptionalString(formData, 'postalCode')
+		},
+		vulnerability: {
+			...draft.userData.vulnerability,
+			reasons: getStringList(
+				formData,
+				'vulnerabilityReasons'
+			) as CertificateDraft['userData']['vulnerability']['reasons']
+		}
+	}
+})
+
+const correctionFields = [
+	['userData.identity.givenNames', (draft: CertificateDraft) => draft.userData.identity.givenNames],
+	[
+		'userData.identity.familyNames',
+		(draft: CertificateDraft) => draft.userData.identity.familyNames
+	],
+	[
+		'userData.identity.documentType',
+		(draft: CertificateDraft) => draft.userData.identity.documentType
+	],
+	[
+		'userData.identity.documentNumber',
+		(draft: CertificateDraft) => draft.userData.identity.documentNumber
+	],
+	[
+		'userData.identity.dateOfBirth',
+		(draft: CertificateDraft) => draft.userData.identity.dateOfBirth
+	],
+	[
+		'userData.identity.nationality',
+		(draft: CertificateDraft) => draft.userData.identity.nationality
+	],
+	['userData.contact.email', (draft: CertificateDraft) => draft.userData.contact.email],
+	['userData.contact.phone', (draft: CertificateDraft) => draft.userData.contact.phone],
+	[
+		'userData.location.addressLine1',
+		(draft: CertificateDraft) => draft.userData.location.addressLine1
+	],
+	[
+		'userData.location.addressLine2',
+		(draft: CertificateDraft) => draft.userData.location.addressLine2
+	],
+	[
+		'userData.location.municipality',
+		(draft: CertificateDraft) => draft.userData.location.municipality
+	],
+	['userData.location.province', (draft: CertificateDraft) => draft.userData.location.province],
+	['userData.location.postalCode', (draft: CertificateDraft) => draft.userData.location.postalCode],
+	[
+		'userData.vulnerability.reasons',
+		(draft: CertificateDraft) => draft.userData.vulnerability.reasons
+	]
+] as const
+
+const valueChanged = (from: unknown, to: unknown) =>
+	JSON.stringify(from ?? null) !== JSON.stringify(to ?? null)
+
+const buildCorrections = (
+	before: CertificateDraft,
+	after: CertificateDraft,
+	type: CertificateCorrectionType,
+	note?: string
+) =>
+	correctionFields
+		.map(([fieldPath, getter]) => ({
+			fieldPath,
+			from: getter(before) ?? null,
+			to: getter(after) ?? null,
+			type,
+			note
+		}))
+		.filter((correction) => valueChanged(correction.from, correction.to))
 
 export const load: PageServerLoad = async ({ locals, params }) => {
 	const session = requirePermission(locals, 'handoff:review')
@@ -54,9 +188,14 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 			status: review.status,
 			createdAt: review.createdAt,
 			updatedAt: review.updatedAt,
-			verification: review.verification
+			verification: review.verification,
+			draftSnapshot: parseCertificateDraft(review.draftSnapshot)
 		},
 		draft,
+		vulnerabilityReasonOptions: VULNERABILITY_REASON_VALUES.map((value) => ({
+			value,
+			label: vulnerabilityReasonLabel(value)
+		})),
 		canMarkReadyToIssue: session.permissions.includes('certificate:prepare'),
 		canIssueCertificate:
 			session.permissions.includes('certificate:issue') &&
@@ -67,6 +206,89 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 }
 
 export const actions: Actions = {
+	updateReviewedData: async ({ request, params, locals }) => {
+		const session = requirePermission(locals, 'handoff:review')
+		const repository = getOrgPortalRepository()
+
+		if (!repository) {
+			error(503, 'El almacenamiento del portal de organizaciones no está configurado.')
+		}
+
+		const review = await repository.findCertificateHandoffReviewById(params.id)
+
+		if (!review || review.organisationId !== session.organisationId) {
+			error(404, 'Revisión no encontrada.')
+		}
+
+		if (review.status !== 'in_review') {
+			return fail(400, {
+				error: 'Solo se pueden corregir datos mientras la revisión está en curso.'
+			})
+		}
+
+		const formData = await request.formData()
+		const reviewedData = withReviewedDataFromForm(review.reviewedData, formData)
+		const validation = validateCertificateDraft(reviewedData)
+
+		if (!validation.ok) {
+			return fail(400, {
+				error: 'Revisa los datos corregidos del certificado.',
+				issues: validation.issues
+			})
+		}
+
+		const corrections = buildCorrections(
+			review.reviewedData,
+			validation.value,
+			getCorrectionType(formData),
+			getOptionalString(formData, 'correctionNote')
+		)
+
+		if (corrections.length === 0) {
+			return fail(400, { error: 'No se ha modificado ningún dato.' })
+		}
+
+		if (formData.get('correctionsConfirmed') !== 'yes') {
+			return fail(400, {
+				error:
+					'Confirma que la organización ha comprobado y asume responsabilidad por las modificaciones.'
+			})
+		}
+
+		const updated = await repository.updateCertificateHandoffReviewReviewedData({
+			reviewId: review.id,
+			memberId: session.memberId,
+			reviewedData: validation.value,
+			corrections
+		})
+
+		if (!updated) {
+			error(409, 'No se pudo actualizar la revisión.')
+		}
+
+		await writeAuditEvent({
+			organisationId: review.organisationId,
+			memberId: session.memberId,
+			handoffId: review.handoffId,
+			reviewId: review.id,
+			eventType: 'certificate.review.corrected',
+			eventData: {
+				correctionType: getCorrectionType(formData),
+				correctionNote: getOptionalString(formData, 'correctionNote'),
+				verificationReset: true,
+				changes: corrections.map(({ fieldPath, from, to, type }) => ({
+					fieldPath,
+					from,
+					to,
+					type
+				}))
+			},
+			request
+		})
+
+		redirect(303, `/reviews/${review.id}`)
+	},
+
 	save: async ({ locals, params, request }) => {
 		const session = requirePermission(locals, 'handoff:review')
 		const repository = getOrgPortalRepository()

--- a/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
@@ -1,10 +1,13 @@
 import {
+	CERTIFICATE_DRAFT_REVIEW_FIELDS,
 	type CertificateDraft,
 	generateVulnerabilityCertificatePdf,
+	getCertificateDraftReviewFieldValue,
 	parseCertificateDraft,
 	parseCertificateIssueRequest,
 	VULNERABILITY_REASON_VALUES,
-	validateCertificateDraft
+	validateCertificateDraft,
+	withCertificateDraftReviewDataFromForm
 } from '@primer-paso/certificate'
 import type { CertificateCorrectionType, VerificationReview } from '@primer-paso/db'
 import { signPdfWithOrganisationCertificate } from '@primer-paso/signing-client'
@@ -50,101 +53,12 @@ const getOptionalString = (formData: FormData, name: string) => {
 	return value.length > 0 ? value : undefined
 }
 
-const getStringList = (formData: FormData, name: string) =>
-	formData.getAll(name).map(String).filter(Boolean)
-
 const getCorrectionType = (formData: FormData): CertificateCorrectionType => {
 	const value = String(formData.get('correctionType') ?? 'confirmed_with_applicant')
 	return CORRECTION_TYPES.includes(value as CertificateCorrectionType)
 		? (value as CertificateCorrectionType)
 		: 'confirmed_with_applicant'
 }
-
-const withReviewedDataFromForm = (
-	draft: CertificateDraft,
-	formData: FormData
-): CertificateDraft => ({
-	...draft,
-	userData: {
-		...draft.userData,
-		identity: {
-			...draft.userData.identity,
-			givenNames: getString(formData, 'givenNames'),
-			familyNames: getString(formData, 'familyNames'),
-			documentType: getString(
-				formData,
-				'documentType'
-			) as CertificateDraft['userData']['identity']['documentType'],
-			documentNumber: getString(formData, 'documentNumber'),
-			dateOfBirth: getOptionalString(formData, 'dateOfBirth'),
-			nationality: getOptionalString(formData, 'nationality')
-		},
-		contact: {
-			...draft.userData.contact,
-			email: getString(formData, 'email'),
-			phone: getOptionalString(formData, 'phone')
-		},
-		location: {
-			...draft.userData.location,
-			addressLine1: getString(formData, 'addressLine1'),
-			addressLine2: getOptionalString(formData, 'addressLine2'),
-			municipality: getString(formData, 'municipality'),
-			province: getString(formData, 'province'),
-			postalCode: getOptionalString(formData, 'postalCode')
-		},
-		vulnerability: {
-			...draft.userData.vulnerability,
-			reasons: getStringList(
-				formData,
-				'vulnerabilityReasons'
-			) as CertificateDraft['userData']['vulnerability']['reasons']
-		}
-	}
-})
-
-const correctionFields = [
-	['userData.identity.givenNames', (draft: CertificateDraft) => draft.userData.identity.givenNames],
-	[
-		'userData.identity.familyNames',
-		(draft: CertificateDraft) => draft.userData.identity.familyNames
-	],
-	[
-		'userData.identity.documentType',
-		(draft: CertificateDraft) => draft.userData.identity.documentType
-	],
-	[
-		'userData.identity.documentNumber',
-		(draft: CertificateDraft) => draft.userData.identity.documentNumber
-	],
-	[
-		'userData.identity.dateOfBirth',
-		(draft: CertificateDraft) => draft.userData.identity.dateOfBirth
-	],
-	[
-		'userData.identity.nationality',
-		(draft: CertificateDraft) => draft.userData.identity.nationality
-	],
-	['userData.contact.email', (draft: CertificateDraft) => draft.userData.contact.email],
-	['userData.contact.phone', (draft: CertificateDraft) => draft.userData.contact.phone],
-	[
-		'userData.location.addressLine1',
-		(draft: CertificateDraft) => draft.userData.location.addressLine1
-	],
-	[
-		'userData.location.addressLine2',
-		(draft: CertificateDraft) => draft.userData.location.addressLine2
-	],
-	[
-		'userData.location.municipality',
-		(draft: CertificateDraft) => draft.userData.location.municipality
-	],
-	['userData.location.province', (draft: CertificateDraft) => draft.userData.location.province],
-	['userData.location.postalCode', (draft: CertificateDraft) => draft.userData.location.postalCode],
-	[
-		'userData.vulnerability.reasons',
-		(draft: CertificateDraft) => draft.userData.vulnerability.reasons
-	]
-] as const
 
 const valueChanged = (from: unknown, to: unknown) =>
 	JSON.stringify(from ?? null) !== JSON.stringify(to ?? null)
@@ -155,15 +69,13 @@ const buildCorrections = (
 	type: CertificateCorrectionType,
 	note?: string
 ) =>
-	correctionFields
-		.map(([fieldPath, getter]) => ({
-			fieldPath,
-			from: getter(before) ?? null,
-			to: getter(after) ?? null,
-			type,
-			note
-		}))
-		.filter((correction) => valueChanged(correction.from, correction.to))
+	CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => ({
+		fieldPath: field.path,
+		from: getCertificateDraftReviewFieldValue(before, field.path) ?? null,
+		to: getCertificateDraftReviewFieldValue(after, field.path) ?? null,
+		type,
+		note
+	})).filter((correction) => valueChanged(correction.from, correction.to))
 
 export const load: PageServerLoad = async ({ locals, params }) => {
 	const session = requirePermission(locals, 'handoff:review')
@@ -227,7 +139,7 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData()
-		const reviewedData = withReviewedDataFromForm(review.reviewedData, formData)
+		const reviewedData = withCertificateDraftReviewDataFromForm(review.reviewedData, formData)
 		const validation = validateCertificateDraft(reviewedData)
 
 		if (!validation.ok) {

--- a/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.server.ts
@@ -1,7 +1,6 @@
 import {
 	CERTIFICATE_DRAFT_REVIEW_FIELDS,
 	type CertificateDraft,
-	generateVulnerabilityCertificatePdf,
 	getCertificateDraftReviewFieldValue,
 	parseCertificateDraft,
 	parseCertificateIssueRequest,
@@ -9,6 +8,7 @@ import {
 	validateCertificateDraft,
 	withCertificateDraftReviewDataFromForm
 } from '@primer-paso/certificate'
+import { generateVulnerabilityCertificatePdf } from '@primer-paso/certificate/pdf'
 import type { CertificateCorrectionType, VerificationReview } from '@primer-paso/db'
 import { signPdfWithOrganisationCertificate } from '@primer-paso/signing-client'
 import { error, fail, redirect } from '@sveltejs/kit'
@@ -69,13 +69,17 @@ const buildCorrections = (
 	type: CertificateCorrectionType,
 	note?: string
 ) =>
-	CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => ({
-		fieldPath: field.path,
-		from: getCertificateDraftReviewFieldValue(before, field.path) ?? null,
-		to: getCertificateDraftReviewFieldValue(after, field.path) ?? null,
-		type,
-		note
-	})).filter((correction) => valueChanged(correction.from, correction.to))
+	CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => {
+		const from = getCertificateDraftReviewFieldValue(before, field.path) ?? null
+		const to = getCertificateDraftReviewFieldValue(after, field.path) ?? null
+		return {
+			fieldPath: field.path,
+			from,
+			to,
+			type,
+			note
+		}
+	}).filter(({ from, to }) => valueChanged(from, to))
 
 export const load: PageServerLoad = async ({ locals, params }) => {
 	const session = requirePermission(locals, 'handoff:review')

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,636 +1,567 @@
 <script lang="ts">
-  import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
-  import DownloadIcon from "@lucide/svelte/icons/download";
-  import PencilIcon from "@lucide/svelte/icons/pencil";
-  import {
-    type CertificateDraft,
-    getCertificateDraftReviewFieldValue,
-    type VulnerabilityReason,
-  } from "@primer-paso/certificate";
-  import { Button } from "@primer-paso/ui/button";
-  import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-  } from "@primer-paso/ui/card";
-  import { Separator } from "@primer-paso/ui/separator";
-  import { certificateReviewFields } from "$lib/certificate-review-fields";
-  import { reviewStatusLabel, vulnerabilityReasonLabel } from "$lib/labels";
-  import ModifiedNote from "$lib/ModifiedNote.svelte";
-  import ReviewInputField from "$lib/ReviewInputField.svelte";
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
+import DownloadIcon from '@lucide/svelte/icons/download'
+import PencilIcon from '@lucide/svelte/icons/pencil'
+import {
+	type CertificateDraft,
+	getCertificateDraftReviewFieldValue,
+	type VulnerabilityReason
+} from '@primer-paso/certificate'
+import { Button } from '@primer-paso/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
+import { Separator } from '@primer-paso/ui/separator'
+import { certificateReviewFields } from '$lib/certificate-review-fields'
+import { reviewStatusLabel, vulnerabilityReasonLabel } from '$lib/labels'
+import ModifiedNote from '$lib/ModifiedNote.svelte'
+import ReviewInputField from '$lib/ReviewInputField.svelte'
 
-  let { data, form } = $props();
+let { data, form } = $props()
 
-  type VerificationFormValue = {
-    passportOrIdentityDocumentChecked: boolean;
-    userInformationConfirmed: boolean;
-    vulnerabilityInformationReviewed: boolean;
-  };
+type VerificationFormValue = {
+	passportOrIdentityDocumentChecked: boolean
+	userInformationConfirmed: boolean
+	vulnerabilityInformationReviewed: boolean
+}
 
-  const emptyVerification: VerificationFormValue = {
-    passportOrIdentityDocumentChecked: false,
-    userInformationConfirmed: false,
-    vulnerabilityInformationReviewed: false,
-  };
+const emptyVerification: VerificationFormValue = {
+	passportOrIdentityDocumentChecked: false,
+	userInformationConfirmed: false,
+	vulnerabilityInformationReviewed: false
+}
 
-  const formVerification = $derived.by(() => {
-    if (form && "verification" in form) {
-      return form.verification as VerificationFormValue;
-    }
+const formVerification = $derived.by(() => {
+	if (form && 'verification' in form) {
+		return form.verification as VerificationFormValue
+	}
 
-    return undefined;
-  });
+	return undefined
+})
 
-  const identity = $derived(data.draft.userData.identity);
-  const contact = $derived(data.draft.userData.contact);
-  const location = $derived(data.draft.userData.location);
-  const vulnerability = $derived(data.draft.userData.vulnerability);
-  const review = $derived(data.review);
-  const verification = $derived(
-    formVerification ?? review.verification ?? emptyVerification,
-  );
-  const original = $derived(review.draftSnapshot ?? data.draft);
-  const canCorrect = $derived(review.status === "in_review");
-  const persisted = $derived(data.draft);
+const identity = $derived(data.draft.userData.identity)
+const contact = $derived(data.draft.userData.contact)
+const location = $derived(data.draft.userData.location)
+const vulnerability = $derived(data.draft.userData.vulnerability)
+const review = $derived(data.review)
+const verification = $derived(formVerification ?? review.verification ?? emptyVerification)
+const original = $derived(review.draftSnapshot ?? data.draft)
+const canCorrect = $derived(review.status === 'in_review')
+const persisted = $derived(data.draft)
 
-  let reviewedDraft = $state<CertificateDraft>(structuredClone(data.draft));
-  let loadedReviewId = $state<string | undefined>(undefined);
+let reviewedDraft = $state<CertificateDraft>(structuredClone(data.draft))
+let loadedReviewId = $state<string | undefined>(undefined)
 
-  const differs = (current: unknown, previous: unknown) =>
-    JSON.stringify(current ?? null) !== JSON.stringify(previous ?? null);
+const differs = (current: unknown, previous: unknown) =>
+	JSON.stringify(current ?? null) !== JSON.stringify(previous ?? null)
 
-  let editingIdentity = $state(false);
-  let editingContact = $state(false);
-  let editingVulnerability = $state(false);
+let editingIdentity = $state(false)
+let editingContact = $state(false)
+let editingVulnerability = $state(false)
 
-  // Keep local edit state when the form is being used, but reset it if SvelteKit
-  // reuses this component instance for a different review.
-  $effect(() => {
-    const id = data.review.id;
-    if (loadedReviewId === undefined) {
-      loadedReviewId = id;
-      return;
-    }
-    if (loadedReviewId === id) return;
+// Keep local edit state when the form is being used, but reset it if SvelteKit
+// reuses this component instance for a different review.
+$effect(() => {
+	const id = data.review.id
+	if (loadedReviewId === undefined) {
+		loadedReviewId = id
+		return
+	}
+	if (loadedReviewId === id) return
 
-    loadedReviewId = id;
-    reviewedDraft = structuredClone(data.draft);
-    editingIdentity = false;
-    editingContact = false;
-    editingVulnerability = false;
-  });
+	loadedReviewId = id
+	reviewedDraft = structuredClone(data.draft)
+	editingIdentity = false
+	editingContact = false
+	editingVulnerability = false
+})
 
-  const toggleVulnerabilityReason = (value: VulnerabilityReason) => {
-    if (!editingVulnerability || !canCorrect) return;
+const toggleVulnerabilityReason = (value: VulnerabilityReason) => {
+	if (!editingVulnerability || !canCorrect) return
 
-    if (reviewedDraft.userData.vulnerability.reasons.includes(value)) {
-      reviewedDraft.userData.vulnerability.reasons =
-        reviewedDraft.userData.vulnerability.reasons.filter(
-          (reason) => reason !== value,
-        );
-      return;
-    }
+	if (reviewedDraft.userData.vulnerability.reasons.includes(value)) {
+		reviewedDraft.userData.vulnerability.reasons =
+			reviewedDraft.userData.vulnerability.reasons.filter((reason) => reason !== value)
+		return
+	}
 
-    reviewedDraft.userData.vulnerability.reasons = [
-      ...reviewedDraft.userData.vulnerability.reasons,
-      value,
-    ];
-  };
+	reviewedDraft.userData.vulnerability.reasons = [
+		...reviewedDraft.userData.vulnerability.reasons,
+		value
+	]
+}
 
-  type Modification = {
-    label: string;
-    from: string;
-    to: string;
-  };
+type Modification = {
+	label: string
+	from: string
+	to: string
+}
 
-  const display = (value: unknown) => {
-    if (Array.isArray(value)) {
-      return value.map((item) => vulnerabilityReasonLabel(item)).join(", ");
-    }
+const display = (value: unknown) => {
+	if (Array.isArray(value)) {
+		return value.map((item) => vulnerabilityReasonLabel(item)).join(', ')
+	}
 
-    if (value === undefined || value === null || value === "") {
-      return "Sin dato";
-    }
+	if (value === undefined || value === null || value === '') {
+		return 'Sin dato'
+	}
 
-    return String(value);
-  };
+	return String(value)
+}
 
-  const buildModifications = (
-    fromDraft: CertificateDraft,
-    toDraft: CertificateDraft,
-  ): Modification[] =>
-    certificateReviewFields
-      .map((field) => {
-        const from = getCertificateDraftReviewFieldValue(fromDraft, field.path);
-        const to = getCertificateDraftReviewFieldValue(toDraft, field.path);
-        return {
-          label: field.label,
-          from: display(from),
-          to: display(to),
-          changed: differs(from, to),
-        };
-      })
-      .filter((modification) => modification.changed)
-      .map(({ label, from, to }) => ({ label, from, to }));
+const buildModifications = (
+	fromDraft: CertificateDraft,
+	toDraft: CertificateDraft
+): Modification[] =>
+	certificateReviewFields
+		.map((field) => {
+			const from = getCertificateDraftReviewFieldValue(fromDraft, field.path)
+			const to = getCertificateDraftReviewFieldValue(toDraft, field.path)
+			return {
+				label: field.label,
+				from: display(from),
+				to: display(to),
+				changed: differs(from, to)
+			}
+		})
+		.filter((modification) => modification.changed)
+		.map(({ label, from, to }) => ({ label, from, to }))
 
-  const savedModifications = $derived(buildModifications(original, persisted));
-  const pendingModifications = $derived(
-    buildModifications(persisted, reviewedDraft),
-  );
+const savedModifications = $derived(buildModifications(original, persisted))
+const pendingModifications = $derived(buildModifications(persisted, reviewedDraft))
 
-  type EditableFieldSection = "identity" | "contact" | "location";
+type EditableFieldSection = 'identity' | 'contact' | 'location'
 
-  type EditableTextField = (typeof certificateReviewFields)[number] & {
-    section: EditableFieldSection;
-    widget: "text" | "email" | "date" | "select";
-  };
+type EditableTextField = (typeof certificateReviewFields)[number] & {
+	section: EditableFieldSection
+	widget: 'text' | 'email' | 'date' | 'select'
+}
 
-  const editableFields = $derived(
-    certificateReviewFields.filter(
-      (field): field is EditableTextField =>
-        field.section === "identity" ||
-        field.section === "contact" ||
-        field.section === "location",
-    ),
-  );
+const editableFields = $derived(
+	certificateReviewFields.filter(
+		(field): field is EditableTextField =>
+			field.section === 'identity' || field.section === 'contact' || field.section === 'location'
+	)
+)
 
-  const identityFields = $derived(
-    editableFields.filter((field) => field.section === "identity"),
-  );
-  const contactLocationFields = $derived(
-    editableFields.filter(
-      (field) => field.section === "contact" || field.section === "location",
-    ),
-  );
+const identityFields = $derived(editableFields.filter((field) => field.section === 'identity'))
+const contactLocationFields = $derived(
+	editableFields.filter((field) => field.section === 'contact' || field.section === 'location')
+)
 
-  const inputTypeFor = (field: EditableTextField) => {
-    if (field.widget === "email" || field.widget === "date")
-      return field.widget;
-    return "text";
-  };
+const inputTypeFor = (field: EditableTextField) => {
+	if (field.widget === 'email' || field.widget === 'date') return field.widget
+	return 'text'
+}
 
-  const fieldValue = (field: EditableTextField) =>
-    getCertificateDraftReviewFieldValue(reviewedDraft, field.path) as
-      | string
-      | undefined;
+const fieldValue = (field: EditableTextField) =>
+	getCertificateDraftReviewFieldValue(reviewedDraft, field.path) as string | undefined
 
-  const originalFieldValue = (field: EditableTextField) =>
-    getCertificateDraftReviewFieldValue(original, field.path);
+const originalFieldValue = (field: EditableTextField) =>
+	getCertificateDraftReviewFieldValue(original, field.path)
 
-  const setDraftValue = (
-    draft: CertificateDraft,
-    path: string,
-    value: string | undefined,
-  ) => {
-    const parts = path.split(".");
-    const key = parts.pop();
-    if (!key) return;
+const setDraftValue = (draft: CertificateDraft, path: string, value: string | undefined) => {
+	const parts = path.split('.')
+	const key = parts.pop()
+	if (!key) return
 
-    const target = parts.reduce<Record<string, unknown>>(
-      (object, part) => object[part] as Record<string, unknown>,
-      draft as unknown as Record<string, unknown>,
-    );
+	const target = parts.reduce<Record<string, unknown>>(
+		(object, part) => object[part] as Record<string, unknown>,
+		draft as unknown as Record<string, unknown>
+	)
 
-    target[key] = value;
-  };
+	target[key] = value
+}
 
-  const normaliseFieldValue = (
-    field: EditableTextField,
-    value: string | undefined,
-  ) => {
-    if (field.kind === "optional-string" && value === "") return undefined;
-    return value ?? "";
-  };
+const normaliseFieldValue = (field: EditableTextField, value: string | undefined) => {
+	if (field.kind === 'optional-string' && value === '') return undefined
+	return value ?? ''
+}
 
-  const setReviewedDraftFieldValue = (
-    field: EditableTextField,
-    value: string | undefined,
-  ) => {
-    setDraftValue(reviewedDraft, field.path, normaliseFieldValue(field, value));
-  };
+const setReviewedDraftFieldValue = (field: EditableTextField, value: string | undefined) => {
+	setDraftValue(reviewedDraft, field.path, normaliseFieldValue(field, value))
+}
 
-  const hasPendingModifications = $derived(pendingModifications.length > 0);
+const hasPendingModifications = $derived(pendingModifications.length > 0)
 
-  const statusTone = $derived(
-    review.status === "issued"
-      ? "success"
-      : review.status === "ready_to_issue"
-        ? "info"
-        : "warning",
-  );
+const statusTone = $derived(
+	review.status === 'issued' ? 'success' : review.status === 'ready_to_issue' ? 'info' : 'warning'
+)
 </script>
 
 <svelte:head>
-  <title
-    >Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title
-  >
+	<title>Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title>
 </svelte:head>
 
 <div class="stack-lg">
-  <header class="section-block">
-    <p class="eyebrow">Borrador de certificado</p>
-    <h1 class="page-title">Revisar el borrador del certificado</h1>
-    <div class="actions">
-      <span class="status-pill" data-tone={statusTone}
-        >{reviewStatusLabel(review.status)}</span
-      >
-    </div>
-  </header>
+	<header class="section-block">
+		<p class="eyebrow">Borrador de certificado</p>
+		<h1 class="page-title">Revisar el borrador del certificado</h1>
+		<div class="actions">
+			<span class="status-pill" data-tone={statusTone}>{reviewStatusLabel(review.status)}</span>
+		</div>
+	</header>
 
-  {#if form?.error}
-    <div class="error-summary" role="alert">
-      <p class="error-summary-title">No se pudo guardar la revisión</p>
-      <p class="error-text">{form.error}</p>
-    </div>
-  {/if}
+	{#if form?.error}
+		<div class="error-summary" role="alert">
+			<p class="error-summary-title">No se pudo guardar la revisión</p>
+			<p class="error-text">{form.error}</p>
+		</div>
+	{/if}
 
-  <div class="panel-subtle">
-    <p class="supporting-text">
-      Este borrador ha sido preparado por la persona solicitante. Antes de
-      emitir el certificado, comprueba la información con la persona y confirma
-      que la organización puede acreditar las circunstancias indicadas.
-    </p>
-  </div>
+	<div class="panel-subtle">
+		<p class="supporting-text">
+			Este borrador ha sido preparado por la persona solicitante. Antes de emitir el certificado,
+			comprueba la información con la persona y confirma que la organización puede acreditar las
+			circunstancias indicadas.
+		</p>
+	</div>
 
-  <Card>
-    <CardHeader>
-      <CardTitle>Datos revisados</CardTitle>
-      <CardDescription>
-        Los datos están bloqueados por defecto. Desbloquea una sección solo si
-        necesitas corregirla durante la entrevista.
-      </CardDescription>
-    </CardHeader>
-    <CardContent>
-      <form method="POST" action="?/updateReviewedData" class="stack">
-        <div class="panel-subtle">
-          <p class="supporting-text">
-            Las correcciones no modifican el borrador original. Si guardas
-            cambios, las confirmaciones de verificación se reiniciarán.
-          </p>
-        </div>
+	<Card>
+		<CardHeader>
+			<CardTitle>Datos revisados</CardTitle>
+			<CardDescription>
+				Los datos están bloqueados por defecto. Desbloquea una sección solo si necesitas corregirla
+				durante la entrevista.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<form method="POST" action="?/updateReviewedData" class="stack">
+				<div class="panel-subtle">
+					<p class="supporting-text">
+						Las correcciones no modifican el borrador original. Si guardas cambios, las
+						confirmaciones de verificación se reiniciarán.
+					</p>
+				</div>
 
-        <section class="stack">
-          <div class="actions justify-between">
-            <h2 class="section-title">Identidad</h2>
-            {#if canCorrect}
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onclick={() => (editingIdentity = !editingIdentity)}
-              >
-                <PencilIcon class="size-4" aria-hidden="true" />
-                {editingIdentity ? "Bloquear identidad" : "Corregir identidad"}
-              </Button>
-            {/if}
-          </div>
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Identidad</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingIdentity = !editingIdentity)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingIdentity ? "Bloquear identidad" : "Corregir identidad"}
+							</Button>
+						{/if}
+					</div>
 
-          <div class="summary-grid">
-            {#each identityFields as field}
-              <ReviewInputField
-                label={field.label}
-                name={field.formName}
-                type={inputTypeFor(field)}
-                value={fieldValue(field)}
-                readonly={!canCorrect || !editingIdentity}
-                modified={differs(fieldValue(field), originalFieldValue(field))}
-                original={display(originalFieldValue(field))}
-                oninput={(event) =>
+					<div class="summary-grid">
+						{#each identityFields as field}
+							<ReviewInputField
+								label={field.label}
+								name={field.formName}
+								type={inputTypeFor(field)}
+								value={fieldValue(field)}
+								readonly={!canCorrect || !editingIdentity}
+								modified={differs(fieldValue(field), originalFieldValue(field))}
+								original={display(originalFieldValue(field))}
+								oninput={(event) =>
                   setReviewedDraftFieldValue(field, event.currentTarget.value)}
-              />
-            {/each}
-          </div>
-        </section>
+							/>
+						{/each}
+					</div>
+				</section>
 
-        <Separator />
+				<Separator />
 
-        <section class="stack">
-          <div class="actions justify-between">
-            <h2 class="section-title">Contacto y dirección</h2>
-            {#if canCorrect}
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onclick={() => (editingContact = !editingContact)}
-              >
-                <PencilIcon class="size-4" aria-hidden="true" />
-                {editingContact ? "Bloquear contacto" : "Corregir contacto"}
-              </Button>
-            {/if}
-          </div>
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Contacto y dirección</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingContact = !editingContact)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingContact ? "Bloquear contacto" : "Corregir contacto"}
+							</Button>
+						{/if}
+					</div>
 
-          <div class="summary-grid">
-            {#each contactLocationFields as field}
-              <ReviewInputField
-                label={field.label}
-                name={field.formName}
-                type={inputTypeFor(field)}
-                value={fieldValue(field)}
-                readonly={!canCorrect || !editingContact}
-                modified={differs(fieldValue(field), originalFieldValue(field))}
-                original={display(originalFieldValue(field))}
-                oninput={(event) =>
+					<div class="summary-grid">
+						{#each contactLocationFields as field}
+							<ReviewInputField
+								label={field.label}
+								name={field.formName}
+								type={inputTypeFor(field)}
+								value={fieldValue(field)}
+								readonly={!canCorrect || !editingContact}
+								modified={differs(fieldValue(field), originalFieldValue(field))}
+								original={display(originalFieldValue(field))}
+								oninput={(event) =>
                   setReviewedDraftFieldValue(field, event.currentTarget.value)}
-              />
-            {/each}
-          </div>
-        </section>
+							/>
+						{/each}
+					</div>
+				</section>
 
-        <Separator />
+				<Separator />
 
-        <section class="stack">
-          <div class="actions justify-between">
-            <h2 class="section-title">Circunstancias de vulnerabilidad</h2>
-            {#if canCorrect}
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onclick={() => (editingVulnerability = !editingVulnerability)}
-              >
-                <PencilIcon class="size-4" aria-hidden="true" />
-                {editingVulnerability
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Circunstancias de vulnerabilidad</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingVulnerability = !editingVulnerability)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingVulnerability
                   ? "Bloquear circunstancias"
                   : "Corregir circunstancias"}
-              </Button>
-            {/if}
-          </div>
-          <fieldset class="form-field">
-            {#each data.vulnerabilityReasonOptions as option}
-              {@const checked =
+							</Button>
+						{/if}
+					</div>
+					<fieldset class="form-field">
+						{#each data.vulnerabilityReasonOptions as option}
+							{@const checked =
                 reviewedDraft.userData.vulnerability.reasons.includes(
                   option.value,
                 )}
-              <label class="check-row">
-                <input
-                  type="checkbox"
-                  value={option.value}
-                  {checked}
-                  disabled={!canCorrect || !editingVulnerability}
-                  onchange={() => toggleVulnerabilityReason(option.value)}
-                />
-                <span>{option.label}</span>
-              </label>
-            {/each}
+							<label class="check-row">
+								<input
+									type="checkbox"
+									value={option.value}
+									{checked}
+									disabled={!canCorrect || !editingVulnerability}
+									onchange={() => toggleVulnerabilityReason(option.value)}
+								>
+								<span>{option.label}</span>
+							</label>
+						{/each}
 
-            {#each reviewedDraft.userData.vulnerability.reasons as reason}
-              <input type="hidden" name="vulnerabilityReasons" value={reason} />
-            {/each}
+						{#each reviewedDraft.userData.vulnerability.reasons as reason}
+							<input type="hidden" name="vulnerabilityReasons" value={reason}>
+						{/each}
 
-            {#if differs(reviewedDraft.userData.vulnerability.reasons, original.userData.vulnerability.reasons)}
-              <ModifiedNote
-                original={display(original.userData.vulnerability.reasons)}
-              />
-            {/if}
-          </fieldset>
-        </section>
+						{#if differs(reviewedDraft.userData.vulnerability.reasons, original.userData.vulnerability.reasons)}
+							<ModifiedNote original={display(original.userData.vulnerability.reasons)} />
+						{/if}
+					</fieldset>
+				</section>
 
-        {#if savedModifications.length > 0}
-          <Separator />
+				{#if savedModifications.length > 0}
+					<Separator />
 
-          <section class="panel-subtle stack">
-            <h2 class="section-title">
-              Modificaciones ya guardadas por la organización
-            </h2>
-            <ul class="grid gap-3">
-              {#each savedModifications as modification}
-                <li class="modified-summary-item">
-                  <strong>{modification.label}</strong>
-                  <span>Original: {modification.from}</span>
-                  <span>Revisado guardado: {modification.to}</span>
-                </li>
-              {/each}
-            </ul>
-          </section>
-        {/if}
+					<section class="panel-subtle stack">
+						<h2 class="section-title">Modificaciones ya guardadas por la organización</h2>
+						<ul class="grid gap-3">
+							{#each savedModifications as modification}
+								<li class="modified-summary-item">
+									<strong>{modification.label}</strong>
+									<span>Original: {modification.from}</span>
+									<span>Revisado guardado: {modification.to}</span>
+								</li>
+							{/each}
+						</ul>
+					</section>
+				{/if}
 
-        {#if pendingModifications.length > 0}
-          <Separator />
+				{#if pendingModifications.length > 0}
+					<Separator />
 
-          <section class="panel-subtle stack">
-            <h2 class="section-title">
-              Modificaciones pendientes de confirmar
-            </h2>
-            <p class="supporting-text">
-              Estos cambios todavía no se han guardado. La organización debe
-              confirmarlos antes de continuar con la verificación.
-            </p>
-            <ul class="grid gap-3">
-              {#each pendingModifications as modification}
-                <li class="modified-summary-item">
-                  <strong>{modification.label}</strong>
-                  <span>Guardado: {modification.from}</span>
-                  <span>Nuevo: {modification.to}</span>
-                </li>
-              {/each}
-            </ul>
-          </section>
+					<section class="panel-subtle stack">
+						<h2 class="section-title">Modificaciones pendientes de confirmar</h2>
+						<p class="supporting-text">
+							Estos cambios todavía no se han guardado. La organización debe confirmarlos antes de
+							continuar con la verificación.
+						</p>
+						<ul class="grid gap-3">
+							{#each pendingModifications as modification}
+								<li class="modified-summary-item">
+									<strong>{modification.label}</strong>
+									<span>Guardado: {modification.from}</span>
+									<span>Nuevo: {modification.to}</span>
+								</li>
+							{/each}
+						</ul>
+					</section>
 
-          <div class="form-field">
-            <label for="correctionType">Tipo de corrección</label>
-            <select
-              id="correctionType"
-              name="correctionType"
-              disabled={!canCorrect}
-            >
-              <option value="confirmed_with_applicant">
-                Confirmado con la persona solicitante
-              </option>
-              <option value="document_verified">Verificado con documento</option
-              >
-              <option value="typo">Corrección tipográfica</option>
-              <option value="standardised_format">Formato normalizado</option>
-              <option value="other">Otra</option>
-            </select>
-          </div>
+					<div class="form-field">
+						<label for="correctionType">Tipo de corrección</label>
+						<select id="correctionType" name="correctionType" disabled={!canCorrect}>
+							<option value="confirmed_with_applicant">
+								Confirmado con la persona solicitante
+							</option>
+							<option value="document_verified">Verificado con documento</option>
+							<option value="typo">Corrección tipográfica</option>
+							<option value="standardised_format">Formato normalizado</option>
+							<option value="other">Otra</option>
+						</select>
+					</div>
 
-          <div class="form-field">
-            <label for="correctionNote">Nota opcional</label>
-            <textarea
-              id="correctionNote"
-              name="correctionNote"
-              rows="3"
-              disabled={!canCorrect}
-            ></textarea>
-          </div>
+					<div class="form-field">
+						<label for="correctionNote">Nota opcional</label>
+						<textarea
+							id="correctionNote"
+							name="correctionNote"
+							rows="3"
+							disabled={!canCorrect}
+						></textarea>
+					</div>
 
-          <label class="check-row panel-subtle">
-            <input
-              type="checkbox"
-              name="correctionsConfirmed"
-              value="yes"
-              required
-              disabled={!canCorrect}
-            />
-            <span>
-              Confirmo que he comprobado estas modificaciones con la persona
-              solicitante o con la documentación aportada, y que la organización
-              asume responsabilidad por los datos revisados.
-            </span>
-          </label>
-        {/if}
+					<label class="check-row panel-subtle">
+						<input
+							type="checkbox"
+							name="correctionsConfirmed"
+							value="yes"
+							required
+							disabled={!canCorrect}
+						>
+						<span>
+							Confirmo que he comprobado estas modificaciones con la persona solicitante o con la
+							documentación aportada, y que la organización asume responsabilidad por los datos
+							revisados.
+						</span>
+					</label>
+				{/if}
 
-        {#if canCorrect}
-          <div class="actions">
-            <Button type="submit" disabled={!hasPendingModifications}>
-              Guardar modificaciones
-            </Button>
-          </div>
-        {:else}
-          <p class="hint">Los datos ya no se pueden corregir en este estado.</p>
-        {/if}
-      </form>
-    </CardContent>
-  </Card>
+				{#if canCorrect}
+					<div class="actions">
+						<Button type="submit" disabled={!hasPendingModifications}>
+							Guardar modificaciones
+						</Button>
+					</div>
+				{:else}
+					<p class="hint">Los datos ya no se pueden corregir en este estado.</p>
+				{/if}
+			</form>
+		</CardContent>
+	</Card>
 
-  <Card>
-    <CardHeader>
-      <CardTitle>Confirmaciones de verificación</CardTitle>
-      <CardDescription>
-        Estas confirmaciones quedarán registradas en el historial de auditoría.
-      </CardDescription>
-    </CardHeader>
-    <CardContent>
-      {#if hasPendingModifications}
-        <div class="error-summary" role="alert">
-          <p class="error-summary-title">Hay modificaciones sin guardar</p>
-          <p class="error-text">
-            Guarda o descarta las modificaciones antes de confirmar la
-            verificación.
-          </p>
-        </div>
-      {/if}
+	<Card>
+		<CardHeader>
+			<CardTitle>Confirmaciones de verificación</CardTitle>
+			<CardDescription>
+				Estas confirmaciones quedarán registradas en el historial de auditoría.
+			</CardDescription>
+		</CardHeader>
+		<CardContent>
+			{#if hasPendingModifications}
+				<div class="error-summary" role="alert">
+					<p class="error-summary-title">Hay modificaciones sin guardar</p>
+					<p class="error-text">
+						Guarda o descarta las modificaciones antes de confirmar la verificación.
+					</p>
+				</div>
+			{/if}
 
-      <form method="POST" action="?/save" class="stack">
-        <div class="check-list">
-          <label class="check-row">
-            <input
-              type="checkbox"
-              name="passportOrIdentityDocumentChecked"
-              value="yes"
-              checked={verification.passportOrIdentityDocumentChecked}
-              disabled={hasPendingModifications}
-              class="mt-1 size-4"
-            />
-            <span class="text-sm leading-6">
-              He comprobado el documento de identidad si la persona lo ha
-              aportado.
-            </span>
-          </label>
-          <label class="check-row">
-            <input
-              type="checkbox"
-              name="userInformationConfirmed"
-              value="yes"
-              checked={verification.userInformationConfirmed}
-              disabled={hasPendingModifications}
-              class="mt-1 size-4"
-            />
-            <span class="text-sm leading-6"
-              >He confirmado estos datos con la persona.</span
-            >
-          </label>
-          <label class="check-row">
-            <input
-              type="checkbox"
-              name="vulnerabilityInformationReviewed"
-              value="yes"
-              checked={verification.vulnerabilityInformationReviewed}
-              disabled={hasPendingModifications}
-              class="mt-1 size-4"
-            />
-            <span class="text-sm leading-6"
-              >He revisado las circunstancias de vulnerabilidad.</span
-            >
-          </label>
-        </div>
-        <Separator />
-        <div class="actions">
-          <Button type="submit" disabled={hasPendingModifications}
-            >Guardar confirmaciones</Button
-          >
-          {#if data.canMarkReadyToIssue}
-            <Button
-              type="submit"
-              formaction="?/ready"
-              variant="secondary"
-              disabled={hasPendingModifications}
-            >
-              Marcar como lista para emitir
-            </Button>
-          {/if}
-        </div>
-      </form>
-    </CardContent>
-  </Card>
+			<form method="POST" action="?/save" class="stack">
+				<div class="check-list">
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="passportOrIdentityDocumentChecked"
+							value="yes"
+							checked={verification.passportOrIdentityDocumentChecked}
+							disabled={hasPendingModifications}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6">
+							He comprobado el documento de identidad si la persona lo ha aportado.
+						</span>
+					</label>
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="userInformationConfirmed"
+							value="yes"
+							checked={verification.userInformationConfirmed}
+							disabled={hasPendingModifications}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6">He confirmado estos datos con la persona.</span>
+					</label>
+					<label class="check-row">
+						<input
+							type="checkbox"
+							name="vulnerabilityInformationReviewed"
+							value="yes"
+							checked={verification.vulnerabilityInformationReviewed}
+							disabled={hasPendingModifications}
+							class="mt-1 size-4"
+						>
+						<span class="text-sm leading-6">He revisado las circunstancias de vulnerabilidad.</span>
+					</label>
+				</div>
+				<Separator />
+				<div class="actions">
+					<Button type="submit" disabled={hasPendingModifications}>Guardar confirmaciones</Button>
+					{#if data.canMarkReadyToIssue}
+						<Button
+							type="submit"
+							formaction="?/ready"
+							variant="secondary"
+							disabled={hasPendingModifications}
+						>
+							Marcar como lista para emitir
+						</Button>
+					{/if}
+				</div>
+			</form>
+		</CardContent>
+	</Card>
 
-  {#if data.canIssueCertificate}
-    <Card>
-      <CardHeader>
-        <CardTitle>Emitir certificado</CardTitle>
-        <CardDescription>
-          Puedes emitir el certificado ahora que la revisión está lista.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        {#if hasPendingModifications}
-          <div class="error-summary" role="alert">
-            <p class="error-summary-title">
-              No se puede emitir con modificaciones sin guardar
-            </p>
-            <p class="error-text">
-              Guarda o descarta las modificaciones antes de emitir el
-              certificado.
-            </p>
-          </div>
-        {/if}
-        <form method="POST" action="?/issue">
-          <Button
-            type="submit"
-            variant="success"
-            disabled={hasPendingModifications}
-          >
-            Emitir certificado
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
-  {/if}
+	{#if data.canIssueCertificate}
+		<Card>
+			<CardHeader>
+				<CardTitle>Emitir certificado</CardTitle>
+				<CardDescription>
+					Puedes emitir el certificado ahora que la revisión está lista.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{#if hasPendingModifications}
+					<div class="error-summary" role="alert">
+						<p class="error-summary-title">No se puede emitir con modificaciones sin guardar</p>
+						<p class="error-text">
+							Guarda o descarta las modificaciones antes de emitir el certificado.
+						</p>
+					</div>
+				{/if}
+				<form method="POST" action="?/issue">
+					<Button type="submit" variant="success" disabled={hasPendingModifications}>
+						Emitir certificado
+					</Button>
+				</form>
+			</CardContent>
+		</Card>
+	{/if}
 
-  {#if data.certificateHref}
-    <Card>
-      <CardHeader><CardTitle>Certificado emitido</CardTitle></CardHeader>
-      <CardContent>
-        <Button href={data.certificateHref} variant="outline">
-          <DownloadIcon class="size-4" aria-hidden="true" />
-          Descargar certificado emitido
-        </Button>
-      </CardContent>
-    </Card>
-  {/if}
+	{#if data.certificateHref}
+		<Card>
+			<CardHeader><CardTitle>Certificado emitido</CardTitle></CardHeader>
+			<CardContent>
+				<Button href={data.certificateHref} variant="outline">
+					<DownloadIcon class="size-4" aria-hidden="true" />
+					Descargar certificado emitido
+				</Button>
+			</CardContent>
+		</Card>
+	{/if}
 
-  <div class="actions">
-    <Button href="/dashboard" variant="ghost">
-      <ArrowLeftIcon class="size-4" aria-hidden="true" />
-      Volver al panel
-    </Button>
-  </div>
+	<div class="actions">
+		<Button href="/dashboard" variant="ghost">
+			<ArrowLeftIcon class="size-4" aria-hidden="true" />
+			Volver al panel
+		</Button>
+	</div>
 </div>
 
 <style>
-  .modified-summary-item {
-    display: grid;
-    gap: 0.25rem;
-    border-inline-start: 0.25rem solid var(--color-warning, #b7791f);
-    padding: 0.75rem;
-    background: color-mix(
-      in srgb,
-      var(--color-warning, #b7791f) 7%,
-      transparent
-    );
-    border-radius: 0.75rem;
-  }
+.modified-summary-item {
+	display: grid;
+	gap: 0.25rem;
+	border-inline-start: 0.25rem solid var(--color-warning, #b7791f);
+	padding: 0.75rem;
+	background: color-mix(in srgb, var(--color-warning, #b7791f) 7%, transparent);
+	border-radius: 0.75rem;
+}
 </style>

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,639 +1,636 @@
 <script lang="ts">
-import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
-import DownloadIcon from '@lucide/svelte/icons/download'
-import PencilIcon from '@lucide/svelte/icons/pencil'
-import {
-	type CertificateDraft,
-	getCertificateDraftReviewFieldValue,
-	type VulnerabilityReason
-} from '@primer-paso/certificate'
-import { Button } from '@primer-paso/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
-import { Separator } from '@primer-paso/ui/separator'
-import { certificateReviewFields } from '$lib/certificate-review-fields'
-import { reviewStatusLabel, vulnerabilityReasonLabel } from '$lib/labels'
-import ModifiedNote from '$lib/ModifiedNote.svelte'
-import ReviewInputField from '$lib/ReviewInputField.svelte'
+  import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
+  import DownloadIcon from "@lucide/svelte/icons/download";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
+  import {
+    type CertificateDraft,
+    getCertificateDraftReviewFieldValue,
+    type VulnerabilityReason,
+  } from "@primer-paso/certificate";
+  import { Button } from "@primer-paso/ui/button";
+  import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "@primer-paso/ui/card";
+  import { Separator } from "@primer-paso/ui/separator";
+  import { certificateReviewFields } from "$lib/certificate-review-fields";
+  import { reviewStatusLabel, vulnerabilityReasonLabel } from "$lib/labels";
+  import ModifiedNote from "$lib/ModifiedNote.svelte";
+  import ReviewInputField from "$lib/ReviewInputField.svelte";
 
-let { data, form } = $props()
+  let { data, form } = $props();
 
-type VerificationFormValue = {
-	passportOrIdentityDocumentChecked: boolean
-	userInformationConfirmed: boolean
-	vulnerabilityInformationReviewed: boolean
-}
+  type VerificationFormValue = {
+    passportOrIdentityDocumentChecked: boolean;
+    userInformationConfirmed: boolean;
+    vulnerabilityInformationReviewed: boolean;
+  };
 
-const emptyVerification: VerificationFormValue = {
-	passportOrIdentityDocumentChecked: false,
-	userInformationConfirmed: false,
-	vulnerabilityInformationReviewed: false
-}
+  const emptyVerification: VerificationFormValue = {
+    passportOrIdentityDocumentChecked: false,
+    userInformationConfirmed: false,
+    vulnerabilityInformationReviewed: false,
+  };
 
-const formVerification = $derived.by(() => {
-	if (form && 'verification' in form) {
-		return form.verification as VerificationFormValue
-	}
+  const formVerification = $derived.by(() => {
+    if (form && "verification" in form) {
+      return form.verification as VerificationFormValue;
+    }
 
-	return undefined
-})
+    return undefined;
+  });
 
-const identity = $derived(data.draft.userData.identity)
-const contact = $derived(data.draft.userData.contact)
-const location = $derived(data.draft.userData.location)
-const vulnerability = $derived(data.draft.userData.vulnerability)
-const review = $derived(data.review)
-const verification = $derived(formVerification ?? review.verification ?? emptyVerification)
-const original = $derived(review.draftSnapshot ?? data.draft)
-const canCorrect = $derived(review.status === 'in_review')
-const persisted = $derived(data.draft)
+  const identity = $derived(data.draft.userData.identity);
+  const contact = $derived(data.draft.userData.contact);
+  const location = $derived(data.draft.userData.location);
+  const vulnerability = $derived(data.draft.userData.vulnerability);
+  const review = $derived(data.review);
+  const verification = $derived(
+    formVerification ?? review.verification ?? emptyVerification,
+  );
+  const original = $derived(review.draftSnapshot ?? data.draft);
+  const canCorrect = $derived(review.status === "in_review");
+  const persisted = $derived(data.draft);
 
-let reviewedIdentity = $state({ ...data.draft.userData.identity })
-let reviewedContact = $state({ ...data.draft.userData.contact })
-let reviewedLocation = $state({ ...data.draft.userData.location })
-let reviewedVulnerabilityReasons = $state([...data.draft.userData.vulnerability.reasons])
-let loadedReviewId = $state<string | undefined>(undefined)
+  let reviewedDraft = $state<CertificateDraft>(structuredClone(data.draft));
+  let loadedReviewId = $state<string | undefined>(undefined);
 
-const differs = (current: unknown, previous: unknown) =>
-	JSON.stringify(current ?? null) !== JSON.stringify(previous ?? null)
+  const differs = (current: unknown, previous: unknown) =>
+    JSON.stringify(current ?? null) !== JSON.stringify(previous ?? null);
 
-let editingIdentity = $state(false)
-let editingContact = $state(false)
-let editingVulnerability = $state(false)
+  let editingIdentity = $state(false);
+  let editingContact = $state(false);
+  let editingVulnerability = $state(false);
 
-// Keep local edit state when the form is being used, but reset it if SvelteKit
-// reuses this component instance for a different review.
-$effect(() => {
-	const id = data.review.id
-	if (loadedReviewId === undefined) {
-		loadedReviewId = id
-		return
-	}
-	if (loadedReviewId === id) return
+  // Keep local edit state when the form is being used, but reset it if SvelteKit
+  // reuses this component instance for a different review.
+  $effect(() => {
+    const id = data.review.id;
+    if (loadedReviewId === undefined) {
+      loadedReviewId = id;
+      return;
+    }
+    if (loadedReviewId === id) return;
 
-	loadedReviewId = id
-	reviewedIdentity = { ...data.draft.userData.identity }
-	reviewedContact = { ...data.draft.userData.contact }
-	reviewedLocation = { ...data.draft.userData.location }
-	reviewedVulnerabilityReasons = [...data.draft.userData.vulnerability.reasons]
-	editingIdentity = false
-	editingContact = false
-	editingVulnerability = false
-})
+    loadedReviewId = id;
+    reviewedDraft = structuredClone(data.draft);
+    editingIdentity = false;
+    editingContact = false;
+    editingVulnerability = false;
+  });
 
-const toggleVulnerabilityReason = (value: VulnerabilityReason) => {
-	if (!editingVulnerability || !canCorrect) return
+  const toggleVulnerabilityReason = (value: VulnerabilityReason) => {
+    if (!editingVulnerability || !canCorrect) return;
 
-	if (reviewedVulnerabilityReasons.includes(value)) {
-		reviewedVulnerabilityReasons = reviewedVulnerabilityReasons.filter((reason) => reason !== value)
-		return
-	}
+    if (reviewedDraft.userData.vulnerability.reasons.includes(value)) {
+      reviewedDraft.userData.vulnerability.reasons =
+        reviewedDraft.userData.vulnerability.reasons.filter(
+          (reason) => reason !== value,
+        );
+      return;
+    }
 
-	reviewedVulnerabilityReasons = [...reviewedVulnerabilityReasons, value]
-}
+    reviewedDraft.userData.vulnerability.reasons = [
+      ...reviewedDraft.userData.vulnerability.reasons,
+      value,
+    ];
+  };
 
-type Modification = {
-	label: string
-	from: string
-	to: string
-}
+  type Modification = {
+    label: string;
+    from: string;
+    to: string;
+  };
 
-const display = (value: unknown) => {
-	if (Array.isArray(value)) {
-		return value.map((item) => vulnerabilityReasonLabel(item)).join(', ')
-	}
+  const display = (value: unknown) => {
+    if (Array.isArray(value)) {
+      return value.map((item) => vulnerabilityReasonLabel(item)).join(", ");
+    }
 
-	if (value === undefined || value === null || value === '') {
-		return 'Sin dato'
-	}
+    if (value === undefined || value === null || value === "") {
+      return "Sin dato";
+    }
 
-	return String(value)
-}
+    return String(value);
+  };
 
-const reviewedDraft = $derived({
-	...persisted,
-	userData: {
-		...persisted.userData,
-		identity: reviewedIdentity,
-		contact: reviewedContact,
-		location: reviewedLocation,
-		vulnerability: {
-			...persisted.userData.vulnerability,
-			reasons: reviewedVulnerabilityReasons
-		}
-	}
-})
+  const buildModifications = (
+    fromDraft: CertificateDraft,
+    toDraft: CertificateDraft,
+  ): Modification[] =>
+    certificateReviewFields
+      .map((field) => {
+        const from = getCertificateDraftReviewFieldValue(fromDraft, field.path);
+        const to = getCertificateDraftReviewFieldValue(toDraft, field.path);
+        return {
+          label: field.label,
+          from: display(from),
+          to: display(to),
+          changed: differs(from, to),
+        };
+      })
+      .filter((modification) => modification.changed)
+      .map(({ label, from, to }) => ({ label, from, to }));
 
-const buildModifications = (
-	fromDraft: CertificateDraft,
-	toDraft: CertificateDraft
-): Modification[] =>
-	certificateReviewFields
-		.map((field) => {
-			const from = getCertificateDraftReviewFieldValue(fromDraft, field.path)
-			const to = getCertificateDraftReviewFieldValue(toDraft, field.path)
-			return {
-				label: field.label,
-				from: display(from),
-				to: display(to),
-				changed: differs(from, to)
-			}
-		})
-		.filter((modification) => modification.changed)
-		.map(({ label, from, to }) => ({ label, from, to }))
+  const savedModifications = $derived(buildModifications(original, persisted));
+  const pendingModifications = $derived(
+    buildModifications(persisted, reviewedDraft),
+  );
 
-const savedModifications = $derived(buildModifications(original, persisted))
-const pendingModifications = $derived(buildModifications(persisted, reviewedDraft))
+  type EditableFieldSection = "identity" | "contact" | "location";
 
-const hasPendingModifications = $derived(pendingModifications.length > 0)
+  type EditableTextField = (typeof certificateReviewFields)[number] & {
+    section: EditableFieldSection;
+    widget: "text" | "email" | "date" | "select";
+  };
 
-const statusTone = $derived(
-	review.status === 'issued' ? 'success' : review.status === 'ready_to_issue' ? 'info' : 'warning'
-)
+  const editableFields = $derived(
+    certificateReviewFields.filter(
+      (field): field is EditableTextField =>
+        field.section === "identity" ||
+        field.section === "contact" ||
+        field.section === "location",
+    ),
+  );
+
+  const identityFields = $derived(
+    editableFields.filter((field) => field.section === "identity"),
+  );
+  const contactLocationFields = $derived(
+    editableFields.filter(
+      (field) => field.section === "contact" || field.section === "location",
+    ),
+  );
+
+  const inputTypeFor = (field: EditableTextField) => {
+    if (field.widget === "email" || field.widget === "date")
+      return field.widget;
+    return "text";
+  };
+
+  const fieldValue = (field: EditableTextField) =>
+    getCertificateDraftReviewFieldValue(reviewedDraft, field.path) as
+      | string
+      | undefined;
+
+  const originalFieldValue = (field: EditableTextField) =>
+    getCertificateDraftReviewFieldValue(original, field.path);
+
+  const setDraftValue = (
+    draft: CertificateDraft,
+    path: string,
+    value: string | undefined,
+  ) => {
+    const parts = path.split(".");
+    const key = parts.pop();
+    if (!key) return;
+
+    const target = parts.reduce<Record<string, unknown>>(
+      (object, part) => object[part] as Record<string, unknown>,
+      draft as unknown as Record<string, unknown>,
+    );
+
+    target[key] = value;
+  };
+
+  const normaliseFieldValue = (
+    field: EditableTextField,
+    value: string | undefined,
+  ) => {
+    if (field.kind === "optional-string" && value === "") return undefined;
+    return value ?? "";
+  };
+
+  const setReviewedDraftFieldValue = (
+    field: EditableTextField,
+    value: string | undefined,
+  ) => {
+    setDraftValue(reviewedDraft, field.path, normaliseFieldValue(field, value));
+  };
+
+  const hasPendingModifications = $derived(pendingModifications.length > 0);
+
+  const statusTone = $derived(
+    review.status === "issued"
+      ? "success"
+      : review.status === "ready_to_issue"
+        ? "info"
+        : "warning",
+  );
 </script>
 
 <svelte:head>
-	<title>Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title>
+  <title
+    >Revisar borrador de certificado | Portal de organizaciones de Primer Paso</title
+  >
 </svelte:head>
 
 <div class="stack-lg">
-	<header class="section-block">
-		<p class="eyebrow">Borrador de certificado</p>
-		<h1 class="page-title">Revisar el borrador del certificado</h1>
-		<div class="actions">
-			<span class="status-pill" data-tone={statusTone}>{reviewStatusLabel(review.status)}</span>
-		</div>
-	</header>
+  <header class="section-block">
+    <p class="eyebrow">Borrador de certificado</p>
+    <h1 class="page-title">Revisar el borrador del certificado</h1>
+    <div class="actions">
+      <span class="status-pill" data-tone={statusTone}
+        >{reviewStatusLabel(review.status)}</span
+      >
+    </div>
+  </header>
 
-	{#if form?.error}
-		<div class="error-summary" role="alert">
-			<p class="error-summary-title">No se pudo guardar la revisión</p>
-			<p class="error-text">{form.error}</p>
-		</div>
-	{/if}
+  {#if form?.error}
+    <div class="error-summary" role="alert">
+      <p class="error-summary-title">No se pudo guardar la revisión</p>
+      <p class="error-text">{form.error}</p>
+    </div>
+  {/if}
 
-	<div class="panel-subtle">
-		<p class="supporting-text">
-			Este borrador ha sido preparado por la persona solicitante. Antes de emitir el certificado,
-			comprueba la información con la persona y confirma que la organización puede acreditar las
-			circunstancias indicadas.
-		</p>
-	</div>
+  <div class="panel-subtle">
+    <p class="supporting-text">
+      Este borrador ha sido preparado por la persona solicitante. Antes de
+      emitir el certificado, comprueba la información con la persona y confirma
+      que la organización puede acreditar las circunstancias indicadas.
+    </p>
+  </div>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>Datos revisados</CardTitle>
-			<CardDescription>
-				Los datos están bloqueados por defecto. Desbloquea una sección solo si necesitas corregirla
-				durante la entrevista.
-			</CardDescription>
-		</CardHeader>
-		<CardContent>
-			<form method="POST" action="?/updateReviewedData" class="stack">
-				<div class="panel-subtle">
-					<p class="supporting-text">
-						Las correcciones no modifican el borrador original. Si guardas cambios, las
-						confirmaciones de verificación se reiniciarán.
-					</p>
-				</div>
+  <Card>
+    <CardHeader>
+      <CardTitle>Datos revisados</CardTitle>
+      <CardDescription>
+        Los datos están bloqueados por defecto. Desbloquea una sección solo si
+        necesitas corregirla durante la entrevista.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <form method="POST" action="?/updateReviewedData" class="stack">
+        <div class="panel-subtle">
+          <p class="supporting-text">
+            Las correcciones no modifican el borrador original. Si guardas
+            cambios, las confirmaciones de verificación se reiniciarán.
+          </p>
+        </div>
 
-				<section class="stack">
-					<div class="actions justify-between">
-						<h2 class="section-title">Identidad</h2>
-						{#if canCorrect}
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => (editingIdentity = !editingIdentity)}
-							>
-								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingIdentity ? "Bloquear identidad" : "Corregir identidad"}
-							</Button>
-						{/if}
-					</div>
+        <section class="stack">
+          <div class="actions justify-between">
+            <h2 class="section-title">Identidad</h2>
+            {#if canCorrect}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onclick={() => (editingIdentity = !editingIdentity)}
+              >
+                <PencilIcon class="size-4" aria-hidden="true" />
+                {editingIdentity ? "Bloquear identidad" : "Corregir identidad"}
+              </Button>
+            {/if}
+          </div>
 
-					<div class="summary-grid">
-						<ReviewInputField
-							label="Nombres"
-							name="givenNames"
-							bind:value={reviewedIdentity.givenNames}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.givenNames,
-                original.userData.identity.givenNames,
-              )}
-							original={display(original.userData.identity.givenNames)}
-						/>
-						<ReviewInputField
-							label="Apellidos"
-							name="familyNames"
-							bind:value={reviewedIdentity.familyNames}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.familyNames,
-                original.userData.identity.familyNames,
-              )}
-							original={display(original.userData.identity.familyNames)}
-						/>
-						<ReviewInputField
-							label="Tipo de documento"
-							name="documentType"
-							bind:value={reviewedIdentity.documentType}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.documentType,
-                original.userData.identity.documentType,
-              )}
-							original={display(original.userData.identity.documentType)}
-						/>
-						<ReviewInputField
-							label="Número de documento"
-							name="documentNumber"
-							bind:value={reviewedIdentity.documentNumber}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.documentNumber,
-                original.userData.identity.documentNumber,
-              )}
-							original={display(original.userData.identity.documentNumber)}
-						/>
-						<ReviewInputField
-							label="Fecha de nacimiento"
-							name="dateOfBirth"
-							type="date"
-							bind:value={reviewedIdentity.dateOfBirth}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.dateOfBirth,
-                original.userData.identity.dateOfBirth,
-              )}
-							original={display(original.userData.identity.dateOfBirth)}
-						/>
-						<ReviewInputField
-							label="Nacionalidad"
-							name="nationality"
-							bind:value={reviewedIdentity.nationality}
-							readonly={!canCorrect || !editingIdentity}
-							modified={differs(
-                reviewedIdentity.nationality,
-                original.userData.identity.nationality,
-              )}
-							original={display(original.userData.identity.nationality)}
-						/>
-					</div>
-				</section>
+          <div class="summary-grid">
+            {#each identityFields as field}
+              <ReviewInputField
+                label={field.label}
+                name={field.formName}
+                type={inputTypeFor(field)}
+                value={fieldValue(field)}
+                readonly={!canCorrect || !editingIdentity}
+                modified={differs(fieldValue(field), originalFieldValue(field))}
+                original={display(originalFieldValue(field))}
+                oninput={(event) =>
+                  setReviewedDraftFieldValue(field, event.currentTarget.value)}
+              />
+            {/each}
+          </div>
+        </section>
 
-				<Separator />
+        <Separator />
 
-				<section class="stack">
-					<div class="actions justify-between">
-						<h2 class="section-title">Contacto y dirección</h2>
-						{#if canCorrect}
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => (editingContact = !editingContact)}
-							>
-								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingContact ? "Bloquear contacto" : "Corregir contacto"}
-							</Button>
-						{/if}
-					</div>
+        <section class="stack">
+          <div class="actions justify-between">
+            <h2 class="section-title">Contacto y dirección</h2>
+            {#if canCorrect}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onclick={() => (editingContact = !editingContact)}
+              >
+                <PencilIcon class="size-4" aria-hidden="true" />
+                {editingContact ? "Bloquear contacto" : "Corregir contacto"}
+              </Button>
+            {/if}
+          </div>
 
-					<div class="summary-grid">
-						<ReviewInputField
-							label="Correo electrónico"
-							name="email"
-							type="email"
-							bind:value={reviewedContact.email}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(reviewedContact.email, original.userData.contact.email)}
-							original={display(original.userData.contact.email)}
-						/>
-						<ReviewInputField
-							label="Teléfono"
-							name="phone"
-							bind:value={reviewedContact.phone}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(reviewedContact.phone, original.userData.contact.phone)}
-							original={display(original.userData.contact.phone)}
-						/>
-						<ReviewInputField
-							label="Dirección"
-							name="addressLine1"
-							bind:value={reviewedLocation.addressLine1}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(
-                reviewedLocation.addressLine1,
-                original.userData.location.addressLine1,
-              )}
-							original={display(original.userData.location.addressLine1)}
-						/>
-						<ReviewInputField
-							label="Dirección, línea 2"
-							name="addressLine2"
-							bind:value={reviewedLocation.addressLine2}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(
-                reviewedLocation.addressLine2,
-                original.userData.location.addressLine2,
-              )}
-							original={display(original.userData.location.addressLine2)}
-						/>
-						<ReviewInputField
-							label="Municipio"
-							name="municipality"
-							bind:value={reviewedLocation.municipality}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(
-                reviewedLocation.municipality,
-                original.userData.location.municipality,
-              )}
-							original={display(original.userData.location.municipality)}
-						/>
-						<ReviewInputField
-							label="Provincia"
-							name="province"
-							bind:value={reviewedLocation.province}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(reviewedLocation.province, original.userData.location.province)}
-							original={display(original.userData.location.province)}
-						/>
-						<ReviewInputField
-							label="Código postal"
-							name="postalCode"
-							bind:value={reviewedLocation.postalCode}
-							readonly={!canCorrect || !editingContact}
-							modified={differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
-							original={display(original.userData.location.postalCode)}
-						/>
-					</div>
-				</section>
+          <div class="summary-grid">
+            {#each contactLocationFields as field}
+              <ReviewInputField
+                label={field.label}
+                name={field.formName}
+                type={inputTypeFor(field)}
+                value={fieldValue(field)}
+                readonly={!canCorrect || !editingContact}
+                modified={differs(fieldValue(field), originalFieldValue(field))}
+                original={display(originalFieldValue(field))}
+                oninput={(event) =>
+                  setReviewedDraftFieldValue(field, event.currentTarget.value)}
+              />
+            {/each}
+          </div>
+        </section>
 
-				<Separator />
+        <Separator />
 
-				<section class="stack">
-					<div class="actions justify-between">
-						<h2 class="section-title">Circunstancias de vulnerabilidad</h2>
-						{#if canCorrect}
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onclick={() => (editingVulnerability = !editingVulnerability)}
-							>
-								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingVulnerability
+        <section class="stack">
+          <div class="actions justify-between">
+            <h2 class="section-title">Circunstancias de vulnerabilidad</h2>
+            {#if canCorrect}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onclick={() => (editingVulnerability = !editingVulnerability)}
+              >
+                <PencilIcon class="size-4" aria-hidden="true" />
+                {editingVulnerability
                   ? "Bloquear circunstancias"
                   : "Corregir circunstancias"}
-							</Button>
-						{/if}
-					</div>
-					<fieldset class="form-field">
-						{#each data.vulnerabilityReasonOptions as option}
-							{@const checked = reviewedVulnerabilityReasons.includes(
-                option.value,
-              )}
-							<label class="check-row">
-								<input
-									type="checkbox"
-									value={option.value}
-									{checked}
-									disabled={!canCorrect || !editingVulnerability}
-									onchange={() => toggleVulnerabilityReason(option.value)}
-								>
-								<span>{option.label}</span>
-							</label>
-						{/each}
+              </Button>
+            {/if}
+          </div>
+          <fieldset class="form-field">
+            {#each data.vulnerabilityReasonOptions as option}
+              {@const checked =
+                reviewedDraft.userData.vulnerability.reasons.includes(
+                  option.value,
+                )}
+              <label class="check-row">
+                <input
+                  type="checkbox"
+                  value={option.value}
+                  {checked}
+                  disabled={!canCorrect || !editingVulnerability}
+                  onchange={() => toggleVulnerabilityReason(option.value)}
+                />
+                <span>{option.label}</span>
+              </label>
+            {/each}
 
-						{#each reviewedVulnerabilityReasons as reason}
-							<input type="hidden" name="vulnerabilityReasons" value={reason}>
-						{/each}
+            {#each reviewedDraft.userData.vulnerability.reasons as reason}
+              <input type="hidden" name="vulnerabilityReasons" value={reason} />
+            {/each}
 
-						{#if differs(reviewedVulnerabilityReasons, original.userData.vulnerability.reasons)}
-							<ModifiedNote
-								original={display(original.userData.vulnerability.reasons)}
-							/>
-						{/if}
-					</fieldset>
-				</section>
+            {#if differs(reviewedDraft.userData.vulnerability.reasons, original.userData.vulnerability.reasons)}
+              <ModifiedNote
+                original={display(original.userData.vulnerability.reasons)}
+              />
+            {/if}
+          </fieldset>
+        </section>
 
-				{#if savedModifications.length > 0}
-					<Separator />
+        {#if savedModifications.length > 0}
+          <Separator />
 
-					<section class="panel-subtle stack">
-						<h2 class="section-title">Modificaciones ya guardadas por la organización</h2>
-						<ul class="grid gap-3">
-							{#each savedModifications as modification}
-								<li class="modified-summary-item">
-									<strong>{modification.label}</strong>
-									<span>Original: {modification.from}</span>
-									<span>Revisado guardado: {modification.to}</span>
-								</li>
-							{/each}
-						</ul>
-					</section>
-				{/if}
+          <section class="panel-subtle stack">
+            <h2 class="section-title">
+              Modificaciones ya guardadas por la organización
+            </h2>
+            <ul class="grid gap-3">
+              {#each savedModifications as modification}
+                <li class="modified-summary-item">
+                  <strong>{modification.label}</strong>
+                  <span>Original: {modification.from}</span>
+                  <span>Revisado guardado: {modification.to}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
+        {/if}
 
-				{#if pendingModifications.length > 0}
-					<Separator />
+        {#if pendingModifications.length > 0}
+          <Separator />
 
-					<section class="panel-subtle stack">
-						<h2 class="section-title">Modificaciones pendientes de confirmar</h2>
-						<p class="supporting-text">
-							Estos cambios todavía no se han guardado. La organización debe confirmarlos antes de
-							continuar con la verificación.
-						</p>
-						<ul class="grid gap-3">
-							{#each pendingModifications as modification}
-								<li class="modified-summary-item">
-									<strong>{modification.label}</strong>
-									<span>Guardado: {modification.from}</span>
-									<span>Nuevo: {modification.to}</span>
-								</li>
-							{/each}
-						</ul>
-					</section>
+          <section class="panel-subtle stack">
+            <h2 class="section-title">
+              Modificaciones pendientes de confirmar
+            </h2>
+            <p class="supporting-text">
+              Estos cambios todavía no se han guardado. La organización debe
+              confirmarlos antes de continuar con la verificación.
+            </p>
+            <ul class="grid gap-3">
+              {#each pendingModifications as modification}
+                <li class="modified-summary-item">
+                  <strong>{modification.label}</strong>
+                  <span>Guardado: {modification.from}</span>
+                  <span>Nuevo: {modification.to}</span>
+                </li>
+              {/each}
+            </ul>
+          </section>
 
-					<div class="form-field">
-						<label for="correctionType">Tipo de corrección</label>
-						<select id="correctionType" name="correctionType" disabled={!canCorrect}>
-							<option value="confirmed_with_applicant">
-								Confirmado con la persona solicitante
-							</option>
-							<option value="document_verified">Verificado con documento</option>
-							<option value="typo">Corrección tipográfica</option>
-							<option value="standardised_format">Formato normalizado</option>
-							<option value="other">Otra</option>
-						</select>
-					</div>
+          <div class="form-field">
+            <label for="correctionType">Tipo de corrección</label>
+            <select
+              id="correctionType"
+              name="correctionType"
+              disabled={!canCorrect}
+            >
+              <option value="confirmed_with_applicant">
+                Confirmado con la persona solicitante
+              </option>
+              <option value="document_verified">Verificado con documento</option
+              >
+              <option value="typo">Corrección tipográfica</option>
+              <option value="standardised_format">Formato normalizado</option>
+              <option value="other">Otra</option>
+            </select>
+          </div>
 
-					<div class="form-field">
-						<label for="correctionNote">Nota opcional</label>
-						<textarea
-							id="correctionNote"
-							name="correctionNote"
-							rows="3"
-							disabled={!canCorrect}
-						></textarea>
-					</div>
+          <div class="form-field">
+            <label for="correctionNote">Nota opcional</label>
+            <textarea
+              id="correctionNote"
+              name="correctionNote"
+              rows="3"
+              disabled={!canCorrect}
+            ></textarea>
+          </div>
 
-					<label class="check-row panel-subtle">
-						<input
-							type="checkbox"
-							name="correctionsConfirmed"
-							value="yes"
-							required
-							disabled={!canCorrect}
-						>
-						<span>
-							Confirmo que he comprobado estas modificaciones con la persona solicitante o con la
-							documentación aportada, y que la organización asume responsabilidad por los datos
-							revisados.
-						</span>
-					</label>
-				{/if}
+          <label class="check-row panel-subtle">
+            <input
+              type="checkbox"
+              name="correctionsConfirmed"
+              value="yes"
+              required
+              disabled={!canCorrect}
+            />
+            <span>
+              Confirmo que he comprobado estas modificaciones con la persona
+              solicitante o con la documentación aportada, y que la organización
+              asume responsabilidad por los datos revisados.
+            </span>
+          </label>
+        {/if}
 
-				{#if canCorrect}
-					<div class="actions">
-						<Button type="submit" disabled={!hasPendingModifications}>
-							Guardar modificaciones
-						</Button>
-					</div>
-				{:else}
-					<p class="hint">Los datos ya no se pueden corregir en este estado.</p>
-				{/if}
-			</form>
-		</CardContent>
-	</Card>
+        {#if canCorrect}
+          <div class="actions">
+            <Button type="submit" disabled={!hasPendingModifications}>
+              Guardar modificaciones
+            </Button>
+          </div>
+        {:else}
+          <p class="hint">Los datos ya no se pueden corregir en este estado.</p>
+        {/if}
+      </form>
+    </CardContent>
+  </Card>
 
-	<Card>
-		<CardHeader>
-			<CardTitle>Confirmaciones de verificación</CardTitle>
-			<CardDescription>
-				Estas confirmaciones quedarán registradas en el historial de auditoría.
-			</CardDescription>
-		</CardHeader>
-		<CardContent>
-			{#if hasPendingModifications}
-				<div class="error-summary" role="alert">
-					<p class="error-summary-title">Hay modificaciones sin guardar</p>
-					<p class="error-text">
-						Guarda o descarta las modificaciones antes de confirmar la verificación.
-					</p>
-				</div>
-			{/if}
+  <Card>
+    <CardHeader>
+      <CardTitle>Confirmaciones de verificación</CardTitle>
+      <CardDescription>
+        Estas confirmaciones quedarán registradas en el historial de auditoría.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      {#if hasPendingModifications}
+        <div class="error-summary" role="alert">
+          <p class="error-summary-title">Hay modificaciones sin guardar</p>
+          <p class="error-text">
+            Guarda o descarta las modificaciones antes de confirmar la
+            verificación.
+          </p>
+        </div>
+      {/if}
 
-			<form method="POST" action="?/save" class="stack">
-				<div class="check-list">
-					<label class="check-row">
-						<input
-							type="checkbox"
-							name="passportOrIdentityDocumentChecked"
-							value="yes"
-							checked={verification.passportOrIdentityDocumentChecked}
-							disabled={hasPendingModifications}
-							class="mt-1 size-4"
-						>
-						<span class="text-sm leading-6">
-							He comprobado el documento de identidad si la persona lo ha aportado.
-						</span>
-					</label>
-					<label class="check-row">
-						<input
-							type="checkbox"
-							name="userInformationConfirmed"
-							value="yes"
-							checked={verification.userInformationConfirmed}
-							disabled={hasPendingModifications}
-							class="mt-1 size-4"
-						>
-						<span class="text-sm leading-6">He confirmado estos datos con la persona.</span>
-					</label>
-					<label class="check-row">
-						<input
-							type="checkbox"
-							name="vulnerabilityInformationReviewed"
-							value="yes"
-							checked={verification.vulnerabilityInformationReviewed}
-							disabled={hasPendingModifications}
-							class="mt-1 size-4"
-						>
-						<span class="text-sm leading-6">He revisado las circunstancias de vulnerabilidad.</span>
-					</label>
-				</div>
-				<Separator />
-				<div class="actions">
-					<Button type="submit" disabled={hasPendingModifications}>Guardar confirmaciones</Button>
-					{#if data.canMarkReadyToIssue}
-						<Button
-							type="submit"
-							formaction="?/ready"
-							variant="secondary"
-							disabled={hasPendingModifications}
-						>
-							Marcar como lista para emitir
-						</Button>
-					{/if}
-				</div>
-			</form>
-		</CardContent>
-	</Card>
+      <form method="POST" action="?/save" class="stack">
+        <div class="check-list">
+          <label class="check-row">
+            <input
+              type="checkbox"
+              name="passportOrIdentityDocumentChecked"
+              value="yes"
+              checked={verification.passportOrIdentityDocumentChecked}
+              disabled={hasPendingModifications}
+              class="mt-1 size-4"
+            />
+            <span class="text-sm leading-6">
+              He comprobado el documento de identidad si la persona lo ha
+              aportado.
+            </span>
+          </label>
+          <label class="check-row">
+            <input
+              type="checkbox"
+              name="userInformationConfirmed"
+              value="yes"
+              checked={verification.userInformationConfirmed}
+              disabled={hasPendingModifications}
+              class="mt-1 size-4"
+            />
+            <span class="text-sm leading-6"
+              >He confirmado estos datos con la persona.</span
+            >
+          </label>
+          <label class="check-row">
+            <input
+              type="checkbox"
+              name="vulnerabilityInformationReviewed"
+              value="yes"
+              checked={verification.vulnerabilityInformationReviewed}
+              disabled={hasPendingModifications}
+              class="mt-1 size-4"
+            />
+            <span class="text-sm leading-6"
+              >He revisado las circunstancias de vulnerabilidad.</span
+            >
+          </label>
+        </div>
+        <Separator />
+        <div class="actions">
+          <Button type="submit" disabled={hasPendingModifications}
+            >Guardar confirmaciones</Button
+          >
+          {#if data.canMarkReadyToIssue}
+            <Button
+              type="submit"
+              formaction="?/ready"
+              variant="secondary"
+              disabled={hasPendingModifications}
+            >
+              Marcar como lista para emitir
+            </Button>
+          {/if}
+        </div>
+      </form>
+    </CardContent>
+  </Card>
 
-	{#if data.canIssueCertificate}
-		<Card>
-			<CardHeader>
-				<CardTitle>Emitir certificado</CardTitle>
-				<CardDescription>
-					Puedes emitir el certificado ahora que la revisión está lista.
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				{#if hasPendingModifications}
-					<div class="error-summary" role="alert">
-						<p class="error-summary-title">No se puede emitir con modificaciones sin guardar</p>
-						<p class="error-text">
-							Guarda o descarta las modificaciones antes de emitir el certificado.
-						</p>
-					</div>
-				{/if}
-				<form method="POST" action="?/issue">
-					<Button type="submit" variant="success" disabled={hasPendingModifications}>
-						Emitir certificado
-					</Button>
-				</form>
-			</CardContent>
-		</Card>
-	{/if}
+  {#if data.canIssueCertificate}
+    <Card>
+      <CardHeader>
+        <CardTitle>Emitir certificado</CardTitle>
+        <CardDescription>
+          Puedes emitir el certificado ahora que la revisión está lista.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {#if hasPendingModifications}
+          <div class="error-summary" role="alert">
+            <p class="error-summary-title">
+              No se puede emitir con modificaciones sin guardar
+            </p>
+            <p class="error-text">
+              Guarda o descarta las modificaciones antes de emitir el
+              certificado.
+            </p>
+          </div>
+        {/if}
+        <form method="POST" action="?/issue">
+          <Button
+            type="submit"
+            variant="success"
+            disabled={hasPendingModifications}
+          >
+            Emitir certificado
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  {/if}
 
-	{#if data.certificateHref}
-		<Card>
-			<CardHeader><CardTitle>Certificado emitido</CardTitle></CardHeader>
-			<CardContent>
-				<Button href={data.certificateHref} variant="outline">
-					<DownloadIcon class="size-4" aria-hidden="true" />
-					Descargar certificado emitido
-				</Button>
-			</CardContent>
-		</Card>
-	{/if}
+  {#if data.certificateHref}
+    <Card>
+      <CardHeader><CardTitle>Certificado emitido</CardTitle></CardHeader>
+      <CardContent>
+        <Button href={data.certificateHref} variant="outline">
+          <DownloadIcon class="size-4" aria-hidden="true" />
+          Descargar certificado emitido
+        </Button>
+      </CardContent>
+    </Card>
+  {/if}
 
-	<div class="actions">
-		<Button href="/dashboard" variant="ghost">
-			<ArrowLeftIcon class="size-4" aria-hidden="true" />
-			Volver al panel
-		</Button>
-	</div>
+  <div class="actions">
+    <Button href="/dashboard" variant="ghost">
+      <ArrowLeftIcon class="size-4" aria-hidden="true" />
+      Volver al panel
+    </Button>
+  </div>
 </div>
 
 <style>
-.modified-summary-item {
-	display: grid;
-	gap: 0.25rem;
-	border-inline-start: 0.25rem solid var(--color-warning, #b7791f);
-	padding: 0.75rem;
-	background: color-mix(in srgb, var(--color-warning, #b7791f) 7%, transparent);
-	border-radius: 0.75rem;
-}
+  .modified-summary-item {
+    display: grid;
+    gap: 0.25rem;
+    border-inline-start: 0.25rem solid var(--color-warning, #b7791f);
+    padding: 0.75rem;
+    background: color-mix(
+      in srgb,
+      var(--color-warning, #b7791f) 7%,
+      transparent
+    );
+    border-radius: 0.75rem;
+  }
 </style>

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -2,11 +2,18 @@
 import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
 import DownloadIcon from '@lucide/svelte/icons/download'
 import PencilIcon from '@lucide/svelte/icons/pencil'
-import type { VulnerabilityReason } from '@primer-paso/certificate'
+import {
+	type CertificateDraft,
+	getCertificateDraftReviewFieldValue,
+	type VulnerabilityReason
+} from '@primer-paso/certificate'
 import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import { Separator } from '@primer-paso/ui/separator'
+import { certificateReviewFields } from '$lib/certificate-review-fields'
 import { reviewStatusLabel, vulnerabilityReasonLabel } from '$lib/labels'
+import ModifiedNote from '$lib/ModifiedNote.svelte'
+import ReviewInputField from '$lib/ReviewInputField.svelte'
 
 let { data, form } = $props()
 
@@ -102,99 +109,40 @@ const display = (value: unknown) => {
 	return String(value)
 }
 
-const savedModifications = $derived.by<Modification[]>(() =>
-	[
-		['Nombres', persisted.userData.identity.givenNames, original.userData.identity.givenNames],
-		['Apellidos', persisted.userData.identity.familyNames, original.userData.identity.familyNames],
-		[
-			'Tipo de documento',
-			persisted.userData.identity.documentType,
-			original.userData.identity.documentType
-		],
-		[
-			'Número de documento',
-			persisted.userData.identity.documentNumber,
-			original.userData.identity.documentNumber
-		],
-		[
-			'Fecha de nacimiento',
-			persisted.userData.identity.dateOfBirth,
-			original.userData.identity.dateOfBirth
-		],
-		[
-			'Nacionalidad',
-			persisted.userData.identity.nationality,
-			original.userData.identity.nationality
-		],
-		['Correo electrónico', persisted.userData.contact.email, original.userData.contact.email],
-		['Teléfono', persisted.userData.contact.phone, original.userData.contact.phone],
-		[
-			'Dirección',
-			persisted.userData.location.addressLine1,
-			original.userData.location.addressLine1
-		],
-		[
-			'Dirección, línea 2',
-			persisted.userData.location.addressLine2,
-			original.userData.location.addressLine2
-		],
-		[
-			'Municipio',
-			persisted.userData.location.municipality,
-			original.userData.location.municipality
-		],
-		['Provincia', persisted.userData.location.province, original.userData.location.province],
-		[
-			'Código postal',
-			persisted.userData.location.postalCode,
-			original.userData.location.postalCode
-		],
-		[
-			'Circunstancias de vulnerabilidad',
-			persisted.userData.vulnerability.reasons,
-			original.userData.vulnerability.reasons
-		]
-	]
-		.filter(([, current, previous]) => differs(current, previous))
-		.map(([label, current, previous]) => ({
-			label: String(label),
-			from: display(previous),
-			to: display(current)
-		}))
-)
+const reviewedDraft = $derived({
+	...persisted,
+	userData: {
+		...persisted.userData,
+		identity: reviewedIdentity,
+		contact: reviewedContact,
+		location: reviewedLocation,
+		vulnerability: {
+			...persisted.userData.vulnerability,
+			reasons: reviewedVulnerabilityReasons
+		}
+	}
+})
 
-const pendingModifications = $derived.by<Modification[]>(() =>
-	[
-		['Nombres', reviewedIdentity.givenNames, persisted.userData.identity.givenNames],
-		['Apellidos', reviewedIdentity.familyNames, persisted.userData.identity.familyNames],
-		['Tipo de documento', reviewedIdentity.documentType, persisted.userData.identity.documentType],
-		[
-			'Número de documento',
-			reviewedIdentity.documentNumber,
-			persisted.userData.identity.documentNumber
-		],
-		['Fecha de nacimiento', reviewedIdentity.dateOfBirth, persisted.userData.identity.dateOfBirth],
-		['Nacionalidad', reviewedIdentity.nationality, persisted.userData.identity.nationality],
-		['Correo electrónico', reviewedContact.email, persisted.userData.contact.email],
-		['Teléfono', reviewedContact.phone, persisted.userData.contact.phone],
-		['Dirección', reviewedLocation.addressLine1, persisted.userData.location.addressLine1],
-		['Dirección, línea 2', reviewedLocation.addressLine2, persisted.userData.location.addressLine2],
-		['Municipio', reviewedLocation.municipality, persisted.userData.location.municipality],
-		['Provincia', reviewedLocation.province, persisted.userData.location.province],
-		['Código postal', reviewedLocation.postalCode, persisted.userData.location.postalCode],
-		[
-			'Circunstancias de vulnerabilidad',
-			reviewedVulnerabilityReasons,
-			persisted.userData.vulnerability.reasons
-		]
-	]
-		.filter(([, current, previous]) => differs(current, previous))
-		.map(([label, current, previous]) => ({
-			label: String(label),
-			from: display(previous),
-			to: display(current)
-		}))
-)
+const buildModifications = (
+	fromDraft: CertificateDraft,
+	toDraft: CertificateDraft
+): Modification[] =>
+	certificateReviewFields
+		.map((field) => {
+			const from = getCertificateDraftReviewFieldValue(fromDraft, field.path)
+			const to = getCertificateDraftReviewFieldValue(toDraft, field.path)
+			return {
+				label: field.label,
+				from: display(from),
+				to: display(to),
+				changed: differs(from, to)
+			}
+		})
+		.filter((modification) => modification.changed)
+		.map(({ label, from, to }) => ({ label, from, to }))
+
+const savedModifications = $derived(buildModifications(original, persisted))
+const pendingModifications = $derived(buildModifications(persisted, reviewedDraft))
 
 const hasPendingModifications = $derived(pendingModifications.length > 0)
 
@@ -259,114 +207,79 @@ const statusTone = $derived(
 								onclick={() => (editingIdentity = !editingIdentity)}
 							>
 								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingIdentity ? 'Bloquear identidad' : 'Corregir identidad'}
+								{editingIdentity ? "Bloquear identidad" : "Corregir identidad"}
 							</Button>
 						{/if}
 					</div>
 
 					<div class="summary-grid">
-						<div class="form-field">
-							<label for="givenNames">Nombres</label>
-							<input
-								id="givenNames"
-								name="givenNames"
-								bind:value={reviewedIdentity.givenNames}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(reviewedIdentity.givenNames, original.userData.identity.givenNames)}
-							>
-							{#if differs(reviewedIdentity.givenNames, original.userData.identity.givenNames)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.givenNames)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="familyNames">Apellidos</label>
-							<input
-								id="familyNames"
-								name="familyNames"
-								bind:value={reviewedIdentity.familyNames}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(reviewedIdentity.familyNames, original.userData.identity.familyNames)}
-							>
-							{#if differs(reviewedIdentity.familyNames, original.userData.identity.familyNames)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.familyNames)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="documentType">Tipo de documento</label>
-							<input
-								id="documentType"
-								name="documentType"
-								bind:value={reviewedIdentity.documentType}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(
-									reviewedIdentity.documentType,
-									original.userData.identity.documentType
-								)}
-							>
-							{#if differs(reviewedIdentity.documentType, original.userData.identity.documentType)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.documentType)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="documentNumber">Número de documento</label>
-							<input
-								id="documentNumber"
-								name="documentNumber"
-								bind:value={reviewedIdentity.documentNumber}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(
-									reviewedIdentity.documentNumber,
-									original.userData.identity.documentNumber
-								)}
-							>
-							{#if differs(reviewedIdentity.documentNumber, original.userData.identity.documentNumber)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.documentNumber)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="dateOfBirth">Fecha de nacimiento</label>
-							<input
-								id="dateOfBirth"
-								name="dateOfBirth"
-								type="date"
-								bind:value={reviewedIdentity.dateOfBirth}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(reviewedIdentity.dateOfBirth, original.userData.identity.dateOfBirth)}
-							>
-							{#if differs(reviewedIdentity.dateOfBirth, original.userData.identity.dateOfBirth)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.dateOfBirth)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="nationality">Nacionalidad</label>
-							<input
-								id="nationality"
-								name="nationality"
-								bind:value={reviewedIdentity.nationality}
-								readonly={!canCorrect || !editingIdentity}
-								data-modified={differs(reviewedIdentity.nationality, original.userData.identity.nationality)}
-							>
-							{#if differs(reviewedIdentity.nationality, original.userData.identity.nationality)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.identity.nationality)}
-								</p>
-							{/if}
-						</div>
+						<ReviewInputField
+							label="Nombres"
+							name="givenNames"
+							bind:value={reviewedIdentity.givenNames}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.givenNames,
+                original.userData.identity.givenNames,
+              )}
+							original={display(original.userData.identity.givenNames)}
+						/>
+						<ReviewInputField
+							label="Apellidos"
+							name="familyNames"
+							bind:value={reviewedIdentity.familyNames}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.familyNames,
+                original.userData.identity.familyNames,
+              )}
+							original={display(original.userData.identity.familyNames)}
+						/>
+						<ReviewInputField
+							label="Tipo de documento"
+							name="documentType"
+							bind:value={reviewedIdentity.documentType}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.documentType,
+                original.userData.identity.documentType,
+              )}
+							original={display(original.userData.identity.documentType)}
+						/>
+						<ReviewInputField
+							label="Número de documento"
+							name="documentNumber"
+							bind:value={reviewedIdentity.documentNumber}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.documentNumber,
+                original.userData.identity.documentNumber,
+              )}
+							original={display(original.userData.identity.documentNumber)}
+						/>
+						<ReviewInputField
+							label="Fecha de nacimiento"
+							name="dateOfBirth"
+							type="date"
+							bind:value={reviewedIdentity.dateOfBirth}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.dateOfBirth,
+                original.userData.identity.dateOfBirth,
+              )}
+							original={display(original.userData.identity.dateOfBirth)}
+						/>
+						<ReviewInputField
+							label="Nacionalidad"
+							name="nationality"
+							bind:value={reviewedIdentity.nationality}
+							readonly={!canCorrect || !editingIdentity}
+							modified={differs(
+                reviewedIdentity.nationality,
+                original.userData.identity.nationality,
+              )}
+							original={display(original.userData.identity.nationality)}
+						/>
 					</div>
 				</section>
 
@@ -383,133 +296,78 @@ const statusTone = $derived(
 								onclick={() => (editingContact = !editingContact)}
 							>
 								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingContact ? 'Bloquear contacto' : 'Corregir contacto'}
+								{editingContact ? "Bloquear contacto" : "Corregir contacto"}
 							</Button>
 						{/if}
 					</div>
 
 					<div class="summary-grid">
-						<div class="form-field">
-							<label for="email">Correo electrónico</label>
-							<input
-								id="email"
-								name="email"
-								type="email"
-								bind:value={reviewedContact.email}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(reviewedContact.email, original.userData.contact.email)}
-							>
-							{#if differs(reviewedContact.email, original.userData.contact.email)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.contact.email)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="phone">Teléfono</label>
-							<input
-								id="phone"
-								name="phone"
-								bind:value={reviewedContact.phone}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(reviewedContact.phone, original.userData.contact.phone)}
-							>
-							{#if differs(reviewedContact.phone, original.userData.contact.phone)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.contact.phone)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="addressLine1">Dirección</label>
-							<input
-								id="addressLine1"
-								name="addressLine1"
-								bind:value={reviewedLocation.addressLine1}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(
-									reviewedLocation.addressLine1,
-									original.userData.location.addressLine1
-								)}
-							>
-							{#if differs(reviewedLocation.addressLine1, original.userData.location.addressLine1)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.location.addressLine1)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="addressLine2">Dirección, línea 2</label>
-							<input
-								id="addressLine2"
-								name="addressLine2"
-								bind:value={reviewedLocation.addressLine2}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(
-									reviewedLocation.addressLine2,
-									original.userData.location.addressLine2
-								)}
-							>
-							{#if differs(reviewedLocation.addressLine2, original.userData.location.addressLine2)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.location.addressLine2)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="municipality">Municipio</label>
-							<input
-								id="municipality"
-								name="municipality"
-								bind:value={reviewedLocation.municipality}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(
-									reviewedLocation.municipality,
-									original.userData.location.municipality
-								)}
-							>
-							{#if differs(reviewedLocation.municipality, original.userData.location.municipality)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.location.municipality)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="province">Provincia</label>
-							<input
-								id="province"
-								name="province"
-								bind:value={reviewedLocation.province}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(reviewedLocation.province, original.userData.location.province)}
-							>
-							{#if differs(reviewedLocation.province, original.userData.location.province)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.location.province)}
-								</p>
-							{/if}
-						</div>
-
-						<div class="form-field">
-							<label for="postalCode">Código postal</label>
-							<input
-								id="postalCode"
-								name="postalCode"
-								bind:value={reviewedLocation.postalCode}
-								readonly={!canCorrect || !editingContact}
-								data-modified={differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
-							>
-							{#if differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
-								<p class="modified-note">
-									Modificado. Original: {display(original.userData.location.postalCode)}
-								</p>
-							{/if}
-						</div>
+						<ReviewInputField
+							label="Correo electrónico"
+							name="email"
+							type="email"
+							bind:value={reviewedContact.email}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(reviewedContact.email, original.userData.contact.email)}
+							original={display(original.userData.contact.email)}
+						/>
+						<ReviewInputField
+							label="Teléfono"
+							name="phone"
+							bind:value={reviewedContact.phone}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(reviewedContact.phone, original.userData.contact.phone)}
+							original={display(original.userData.contact.phone)}
+						/>
+						<ReviewInputField
+							label="Dirección"
+							name="addressLine1"
+							bind:value={reviewedLocation.addressLine1}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(
+                reviewedLocation.addressLine1,
+                original.userData.location.addressLine1,
+              )}
+							original={display(original.userData.location.addressLine1)}
+						/>
+						<ReviewInputField
+							label="Dirección, línea 2"
+							name="addressLine2"
+							bind:value={reviewedLocation.addressLine2}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(
+                reviewedLocation.addressLine2,
+                original.userData.location.addressLine2,
+              )}
+							original={display(original.userData.location.addressLine2)}
+						/>
+						<ReviewInputField
+							label="Municipio"
+							name="municipality"
+							bind:value={reviewedLocation.municipality}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(
+                reviewedLocation.municipality,
+                original.userData.location.municipality,
+              )}
+							original={display(original.userData.location.municipality)}
+						/>
+						<ReviewInputField
+							label="Provincia"
+							name="province"
+							bind:value={reviewedLocation.province}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(reviewedLocation.province, original.userData.location.province)}
+							original={display(original.userData.location.province)}
+						/>
+						<ReviewInputField
+							label="Código postal"
+							name="postalCode"
+							bind:value={reviewedLocation.postalCode}
+							readonly={!canCorrect || !editingContact}
+							modified={differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
+							original={display(original.userData.location.postalCode)}
+						/>
 					</div>
 				</section>
 
@@ -526,13 +384,17 @@ const statusTone = $derived(
 								onclick={() => (editingVulnerability = !editingVulnerability)}
 							>
 								<PencilIcon class="size-4" aria-hidden="true" />
-								{editingVulnerability ? 'Bloquear circunstancias' : 'Corregir circunstancias'}
+								{editingVulnerability
+                  ? "Bloquear circunstancias"
+                  : "Corregir circunstancias"}
 							</Button>
 						{/if}
 					</div>
 					<fieldset class="form-field">
 						{#each data.vulnerabilityReasonOptions as option}
-							{@const checked = reviewedVulnerabilityReasons.includes(option.value)}
+							{@const checked = reviewedVulnerabilityReasons.includes(
+                option.value,
+              )}
 							<label class="check-row">
 								<input
 									type="checkbox"
@@ -550,9 +412,9 @@ const statusTone = $derived(
 						{/each}
 
 						{#if differs(reviewedVulnerabilityReasons, original.userData.vulnerability.reasons)}
-							<p class="modified-note">
-								Modificado. Original: {display(original.userData.vulnerability.reasons)}
-							</p>
+							<ModifiedNote
+								original={display(original.userData.vulnerability.reasons)}
+							/>
 						{/if}
 					</fieldset>
 				</section>
@@ -658,8 +520,7 @@ const statusTone = $derived(
 				<div class="error-summary" role="alert">
 					<p class="error-summary-title">Hay modificaciones sin guardar</p>
 					<p class="error-text">
-						Guarda o descarta las modificaciones antes de confirmar la verificación. Si continúas
-						sin guardarlas, el certificado se emitiría con los datos guardados anteriormente.
+						Guarda o descarta las modificaciones antes de confirmar la verificación.
 					</p>
 				</div>
 			{/if}
@@ -748,7 +609,7 @@ const statusTone = $derived(
 
 	{#if data.certificateHref}
 		<Card>
-			<CardHeader> <CardTitle>Certificado emitido</CardTitle> </CardHeader>
+			<CardHeader><CardTitle>Certificado emitido</CardTitle></CardHeader>
 			<CardContent>
 				<Button href={data.certificateHref} variant="outline">
 					<DownloadIcon class="size-4" aria-hidden="true" />
@@ -767,23 +628,6 @@ const statusTone = $derived(
 </div>
 
 <style>
-input[data-modified="true"],
-input[readonly][data-modified="true"] {
-	border-color: var(--color-warning, #b7791f);
-	background: color-mix(in srgb, var(--color-warning, #b7791f) 8%, transparent);
-}
-
-input[readonly] {
-	cursor: default;
-}
-
-.modified-note {
-	margin-top: 0.25rem;
-	font-size: 0.875rem;
-	font-weight: 600;
-	color: var(--color-warning-text, #92400e);
-}
-
 .modified-summary-item {
 	display: grid;
 	gap: 0.25rem;

--- a/apps/org-portal/src/routes/reviews/[id]/+page.svelte
+++ b/apps/org-portal/src/routes/reviews/[id]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left'
 import DownloadIcon from '@lucide/svelte/icons/download'
+import PencilIcon from '@lucide/svelte/icons/pencil'
+import type { VulnerabilityReason } from '@primer-paso/certificate'
 import { Button } from '@primer-paso/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@primer-paso/ui/card'
 import { Separator } from '@primer-paso/ui/separator'
@@ -34,6 +36,167 @@ const location = $derived(data.draft.userData.location)
 const vulnerability = $derived(data.draft.userData.vulnerability)
 const review = $derived(data.review)
 const verification = $derived(formVerification ?? review.verification ?? emptyVerification)
+const original = $derived(review.draftSnapshot ?? data.draft)
+const canCorrect = $derived(review.status === 'in_review')
+const persisted = $derived(data.draft)
+
+let reviewedIdentity = $state({ ...data.draft.userData.identity })
+let reviewedContact = $state({ ...data.draft.userData.contact })
+let reviewedLocation = $state({ ...data.draft.userData.location })
+let reviewedVulnerabilityReasons = $state([...data.draft.userData.vulnerability.reasons])
+let loadedReviewId = $state<string | undefined>(undefined)
+
+const differs = (current: unknown, previous: unknown) =>
+	JSON.stringify(current ?? null) !== JSON.stringify(previous ?? null)
+
+let editingIdentity = $state(false)
+let editingContact = $state(false)
+let editingVulnerability = $state(false)
+
+// Keep local edit state when the form is being used, but reset it if SvelteKit
+// reuses this component instance for a different review.
+$effect(() => {
+	const id = data.review.id
+	if (loadedReviewId === undefined) {
+		loadedReviewId = id
+		return
+	}
+	if (loadedReviewId === id) return
+
+	loadedReviewId = id
+	reviewedIdentity = { ...data.draft.userData.identity }
+	reviewedContact = { ...data.draft.userData.contact }
+	reviewedLocation = { ...data.draft.userData.location }
+	reviewedVulnerabilityReasons = [...data.draft.userData.vulnerability.reasons]
+	editingIdentity = false
+	editingContact = false
+	editingVulnerability = false
+})
+
+const toggleVulnerabilityReason = (value: VulnerabilityReason) => {
+	if (!editingVulnerability || !canCorrect) return
+
+	if (reviewedVulnerabilityReasons.includes(value)) {
+		reviewedVulnerabilityReasons = reviewedVulnerabilityReasons.filter((reason) => reason !== value)
+		return
+	}
+
+	reviewedVulnerabilityReasons = [...reviewedVulnerabilityReasons, value]
+}
+
+type Modification = {
+	label: string
+	from: string
+	to: string
+}
+
+const display = (value: unknown) => {
+	if (Array.isArray(value)) {
+		return value.map((item) => vulnerabilityReasonLabel(item)).join(', ')
+	}
+
+	if (value === undefined || value === null || value === '') {
+		return 'Sin dato'
+	}
+
+	return String(value)
+}
+
+const savedModifications = $derived.by<Modification[]>(() =>
+	[
+		['Nombres', persisted.userData.identity.givenNames, original.userData.identity.givenNames],
+		['Apellidos', persisted.userData.identity.familyNames, original.userData.identity.familyNames],
+		[
+			'Tipo de documento',
+			persisted.userData.identity.documentType,
+			original.userData.identity.documentType
+		],
+		[
+			'Número de documento',
+			persisted.userData.identity.documentNumber,
+			original.userData.identity.documentNumber
+		],
+		[
+			'Fecha de nacimiento',
+			persisted.userData.identity.dateOfBirth,
+			original.userData.identity.dateOfBirth
+		],
+		[
+			'Nacionalidad',
+			persisted.userData.identity.nationality,
+			original.userData.identity.nationality
+		],
+		['Correo electrónico', persisted.userData.contact.email, original.userData.contact.email],
+		['Teléfono', persisted.userData.contact.phone, original.userData.contact.phone],
+		[
+			'Dirección',
+			persisted.userData.location.addressLine1,
+			original.userData.location.addressLine1
+		],
+		[
+			'Dirección, línea 2',
+			persisted.userData.location.addressLine2,
+			original.userData.location.addressLine2
+		],
+		[
+			'Municipio',
+			persisted.userData.location.municipality,
+			original.userData.location.municipality
+		],
+		['Provincia', persisted.userData.location.province, original.userData.location.province],
+		[
+			'Código postal',
+			persisted.userData.location.postalCode,
+			original.userData.location.postalCode
+		],
+		[
+			'Circunstancias de vulnerabilidad',
+			persisted.userData.vulnerability.reasons,
+			original.userData.vulnerability.reasons
+		]
+	]
+		.filter(([, current, previous]) => differs(current, previous))
+		.map(([label, current, previous]) => ({
+			label: String(label),
+			from: display(previous),
+			to: display(current)
+		}))
+)
+
+const pendingModifications = $derived.by<Modification[]>(() =>
+	[
+		['Nombres', reviewedIdentity.givenNames, persisted.userData.identity.givenNames],
+		['Apellidos', reviewedIdentity.familyNames, persisted.userData.identity.familyNames],
+		['Tipo de documento', reviewedIdentity.documentType, persisted.userData.identity.documentType],
+		[
+			'Número de documento',
+			reviewedIdentity.documentNumber,
+			persisted.userData.identity.documentNumber
+		],
+		['Fecha de nacimiento', reviewedIdentity.dateOfBirth, persisted.userData.identity.dateOfBirth],
+		['Nacionalidad', reviewedIdentity.nationality, persisted.userData.identity.nationality],
+		['Correo electrónico', reviewedContact.email, persisted.userData.contact.email],
+		['Teléfono', reviewedContact.phone, persisted.userData.contact.phone],
+		['Dirección', reviewedLocation.addressLine1, persisted.userData.location.addressLine1],
+		['Dirección, línea 2', reviewedLocation.addressLine2, persisted.userData.location.addressLine2],
+		['Municipio', reviewedLocation.municipality, persisted.userData.location.municipality],
+		['Provincia', reviewedLocation.province, persisted.userData.location.province],
+		['Código postal', reviewedLocation.postalCode, persisted.userData.location.postalCode],
+		[
+			'Circunstancias de vulnerabilidad',
+			reviewedVulnerabilityReasons,
+			persisted.userData.vulnerability.reasons
+		]
+	]
+		.filter(([, current, previous]) => differs(current, previous))
+		.map(([label, current, previous]) => ({
+			label: String(label),
+			from: display(previous),
+			to: display(current)
+		}))
+)
+
+const hasPendingModifications = $derived(pendingModifications.length > 0)
 
 const statusTone = $derived(
 	review.status === 'issued' ? 'success' : review.status === 'ready_to_issue' ? 'info' : 'warning'
@@ -69,90 +232,417 @@ const statusTone = $derived(
 	</div>
 
 	<Card>
-		<CardHeader> <CardTitle>Datos de identidad</CardTitle> </CardHeader>
+		<CardHeader>
+			<CardTitle>Datos revisados</CardTitle>
+			<CardDescription>
+				Los datos están bloqueados por defecto. Desbloquea una sección solo si necesitas corregirla
+				durante la entrevista.
+			</CardDescription>
+		</CardHeader>
 		<CardContent>
-			<dl class="summary-grid">
-				<div class="summary-item">
-					<dt class="summary-label">Nombres</dt>
-					<dd class="summary-value">{identity.givenNames}</dd>
+			<form method="POST" action="?/updateReviewedData" class="stack">
+				<div class="panel-subtle">
+					<p class="supporting-text">
+						Las correcciones no modifican el borrador original. Si guardas cambios, las
+						confirmaciones de verificación se reiniciarán.
+					</p>
 				</div>
-				<div class="summary-item">
-					<dt class="summary-label">Apellidos</dt>
-					<dd class="summary-value">{identity.familyNames}</dd>
-				</div>
-				<div class="summary-item">
-					<dt class="summary-label">Tipo de documento</dt>
-					<dd class="summary-value">{identity.documentType}</dd>
-				</div>
-				<div class="summary-item">
-					<dt class="summary-label">Número de documento</dt>
-					<dd class="summary-value">{identity.documentNumber}</dd>
-				</div>
-				{#if identity.dateOfBirth}
-					<div class="summary-item">
-						<dt class="summary-label">Fecha de nacimiento</dt>
-						<dd class="summary-value">{identity.dateOfBirth}</dd>
-					</div>
-				{/if}
-				{#if identity.nationality}
-					<div class="summary-item">
-						<dt class="summary-label">Nacionalidad</dt>
-						<dd class="summary-value">{identity.nationality}</dd>
-					</div>
-				{/if}
-			</dl>
-		</CardContent>
-	</Card>
 
-	<Card>
-		<CardHeader> <CardTitle>Contacto y dirección</CardTitle> </CardHeader>
-		<CardContent>
-			<dl class="summary-grid">
-				<div class="summary-item">
-					<dt class="summary-label">Correo electrónico</dt>
-					<dd class="summary-value">{contact.email}</dd>
-				</div>
-				{#if contact.phone}
-					<div class="summary-item">
-						<dt class="summary-label">Teléfono</dt>
-						<dd class="summary-value">{contact.phone}</dd>
-					</div>
-				{/if}
-				<div class="summary-item">
-					<dt class="summary-label">Dirección</dt>
-					<dd class="summary-value">
-						{location.addressLine1}
-						{#if location.addressLine2}
-							, {location.addressLine2}
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Identidad</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingIdentity = !editingIdentity)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingIdentity ? 'Bloquear identidad' : 'Corregir identidad'}
+							</Button>
 						{/if}
-					</dd>
-				</div>
-				<div class="summary-item">
-					<dt class="summary-label">Municipio</dt>
-					<dd class="summary-value">{location.municipality}</dd>
-				</div>
-				<div class="summary-item">
-					<dt class="summary-label">Provincia</dt>
-					<dd class="summary-value">{location.province}</dd>
-				</div>
-				{#if location.postalCode}
-					<div class="summary-item">
-						<dt class="summary-label">Código postal</dt>
-						<dd class="summary-value">{location.postalCode}</dd>
 					</div>
-				{/if}
-			</dl>
-		</CardContent>
-	</Card>
 
-	<Card>
-		<CardHeader> <CardTitle>Circunstancias de vulnerabilidad</CardTitle> </CardHeader>
-		<CardContent>
-			<ul class="grid gap-2 list-disc ps-5">
-				{#each vulnerability.reasons as reason}
-					<li>{vulnerabilityReasonLabel(reason)}</li>
-				{/each}
-			</ul>
+					<div class="summary-grid">
+						<div class="form-field">
+							<label for="givenNames">Nombres</label>
+							<input
+								id="givenNames"
+								name="givenNames"
+								bind:value={reviewedIdentity.givenNames}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(reviewedIdentity.givenNames, original.userData.identity.givenNames)}
+							>
+							{#if differs(reviewedIdentity.givenNames, original.userData.identity.givenNames)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.givenNames)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="familyNames">Apellidos</label>
+							<input
+								id="familyNames"
+								name="familyNames"
+								bind:value={reviewedIdentity.familyNames}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(reviewedIdentity.familyNames, original.userData.identity.familyNames)}
+							>
+							{#if differs(reviewedIdentity.familyNames, original.userData.identity.familyNames)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.familyNames)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="documentType">Tipo de documento</label>
+							<input
+								id="documentType"
+								name="documentType"
+								bind:value={reviewedIdentity.documentType}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(
+									reviewedIdentity.documentType,
+									original.userData.identity.documentType
+								)}
+							>
+							{#if differs(reviewedIdentity.documentType, original.userData.identity.documentType)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.documentType)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="documentNumber">Número de documento</label>
+							<input
+								id="documentNumber"
+								name="documentNumber"
+								bind:value={reviewedIdentity.documentNumber}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(
+									reviewedIdentity.documentNumber,
+									original.userData.identity.documentNumber
+								)}
+							>
+							{#if differs(reviewedIdentity.documentNumber, original.userData.identity.documentNumber)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.documentNumber)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="dateOfBirth">Fecha de nacimiento</label>
+							<input
+								id="dateOfBirth"
+								name="dateOfBirth"
+								type="date"
+								bind:value={reviewedIdentity.dateOfBirth}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(reviewedIdentity.dateOfBirth, original.userData.identity.dateOfBirth)}
+							>
+							{#if differs(reviewedIdentity.dateOfBirth, original.userData.identity.dateOfBirth)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.dateOfBirth)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="nationality">Nacionalidad</label>
+							<input
+								id="nationality"
+								name="nationality"
+								bind:value={reviewedIdentity.nationality}
+								readonly={!canCorrect || !editingIdentity}
+								data-modified={differs(reviewedIdentity.nationality, original.userData.identity.nationality)}
+							>
+							{#if differs(reviewedIdentity.nationality, original.userData.identity.nationality)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.identity.nationality)}
+								</p>
+							{/if}
+						</div>
+					</div>
+				</section>
+
+				<Separator />
+
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Contacto y dirección</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingContact = !editingContact)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingContact ? 'Bloquear contacto' : 'Corregir contacto'}
+							</Button>
+						{/if}
+					</div>
+
+					<div class="summary-grid">
+						<div class="form-field">
+							<label for="email">Correo electrónico</label>
+							<input
+								id="email"
+								name="email"
+								type="email"
+								bind:value={reviewedContact.email}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(reviewedContact.email, original.userData.contact.email)}
+							>
+							{#if differs(reviewedContact.email, original.userData.contact.email)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.contact.email)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="phone">Teléfono</label>
+							<input
+								id="phone"
+								name="phone"
+								bind:value={reviewedContact.phone}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(reviewedContact.phone, original.userData.contact.phone)}
+							>
+							{#if differs(reviewedContact.phone, original.userData.contact.phone)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.contact.phone)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="addressLine1">Dirección</label>
+							<input
+								id="addressLine1"
+								name="addressLine1"
+								bind:value={reviewedLocation.addressLine1}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(
+									reviewedLocation.addressLine1,
+									original.userData.location.addressLine1
+								)}
+							>
+							{#if differs(reviewedLocation.addressLine1, original.userData.location.addressLine1)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.location.addressLine1)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="addressLine2">Dirección, línea 2</label>
+							<input
+								id="addressLine2"
+								name="addressLine2"
+								bind:value={reviewedLocation.addressLine2}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(
+									reviewedLocation.addressLine2,
+									original.userData.location.addressLine2
+								)}
+							>
+							{#if differs(reviewedLocation.addressLine2, original.userData.location.addressLine2)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.location.addressLine2)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="municipality">Municipio</label>
+							<input
+								id="municipality"
+								name="municipality"
+								bind:value={reviewedLocation.municipality}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(
+									reviewedLocation.municipality,
+									original.userData.location.municipality
+								)}
+							>
+							{#if differs(reviewedLocation.municipality, original.userData.location.municipality)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.location.municipality)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="province">Provincia</label>
+							<input
+								id="province"
+								name="province"
+								bind:value={reviewedLocation.province}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(reviewedLocation.province, original.userData.location.province)}
+							>
+							{#if differs(reviewedLocation.province, original.userData.location.province)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.location.province)}
+								</p>
+							{/if}
+						</div>
+
+						<div class="form-field">
+							<label for="postalCode">Código postal</label>
+							<input
+								id="postalCode"
+								name="postalCode"
+								bind:value={reviewedLocation.postalCode}
+								readonly={!canCorrect || !editingContact}
+								data-modified={differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
+							>
+							{#if differs(reviewedLocation.postalCode, original.userData.location.postalCode)}
+								<p class="modified-note">
+									Modificado. Original: {display(original.userData.location.postalCode)}
+								</p>
+							{/if}
+						</div>
+					</div>
+				</section>
+
+				<Separator />
+
+				<section class="stack">
+					<div class="actions justify-between">
+						<h2 class="section-title">Circunstancias de vulnerabilidad</h2>
+						{#if canCorrect}
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onclick={() => (editingVulnerability = !editingVulnerability)}
+							>
+								<PencilIcon class="size-4" aria-hidden="true" />
+								{editingVulnerability ? 'Bloquear circunstancias' : 'Corregir circunstancias'}
+							</Button>
+						{/if}
+					</div>
+					<fieldset class="form-field">
+						{#each data.vulnerabilityReasonOptions as option}
+							{@const checked = reviewedVulnerabilityReasons.includes(option.value)}
+							<label class="check-row">
+								<input
+									type="checkbox"
+									value={option.value}
+									{checked}
+									disabled={!canCorrect || !editingVulnerability}
+									onchange={() => toggleVulnerabilityReason(option.value)}
+								>
+								<span>{option.label}</span>
+							</label>
+						{/each}
+
+						{#each reviewedVulnerabilityReasons as reason}
+							<input type="hidden" name="vulnerabilityReasons" value={reason}>
+						{/each}
+
+						{#if differs(reviewedVulnerabilityReasons, original.userData.vulnerability.reasons)}
+							<p class="modified-note">
+								Modificado. Original: {display(original.userData.vulnerability.reasons)}
+							</p>
+						{/if}
+					</fieldset>
+				</section>
+
+				{#if savedModifications.length > 0}
+					<Separator />
+
+					<section class="panel-subtle stack">
+						<h2 class="section-title">Modificaciones ya guardadas por la organización</h2>
+						<ul class="grid gap-3">
+							{#each savedModifications as modification}
+								<li class="modified-summary-item">
+									<strong>{modification.label}</strong>
+									<span>Original: {modification.from}</span>
+									<span>Revisado guardado: {modification.to}</span>
+								</li>
+							{/each}
+						</ul>
+					</section>
+				{/if}
+
+				{#if pendingModifications.length > 0}
+					<Separator />
+
+					<section class="panel-subtle stack">
+						<h2 class="section-title">Modificaciones pendientes de confirmar</h2>
+						<p class="supporting-text">
+							Estos cambios todavía no se han guardado. La organización debe confirmarlos antes de
+							continuar con la verificación.
+						</p>
+						<ul class="grid gap-3">
+							{#each pendingModifications as modification}
+								<li class="modified-summary-item">
+									<strong>{modification.label}</strong>
+									<span>Guardado: {modification.from}</span>
+									<span>Nuevo: {modification.to}</span>
+								</li>
+							{/each}
+						</ul>
+					</section>
+
+					<div class="form-field">
+						<label for="correctionType">Tipo de corrección</label>
+						<select id="correctionType" name="correctionType" disabled={!canCorrect}>
+							<option value="confirmed_with_applicant">
+								Confirmado con la persona solicitante
+							</option>
+							<option value="document_verified">Verificado con documento</option>
+							<option value="typo">Corrección tipográfica</option>
+							<option value="standardised_format">Formato normalizado</option>
+							<option value="other">Otra</option>
+						</select>
+					</div>
+
+					<div class="form-field">
+						<label for="correctionNote">Nota opcional</label>
+						<textarea
+							id="correctionNote"
+							name="correctionNote"
+							rows="3"
+							disabled={!canCorrect}
+						></textarea>
+					</div>
+
+					<label class="check-row panel-subtle">
+						<input
+							type="checkbox"
+							name="correctionsConfirmed"
+							value="yes"
+							required
+							disabled={!canCorrect}
+						>
+						<span>
+							Confirmo que he comprobado estas modificaciones con la persona solicitante o con la
+							documentación aportada, y que la organización asume responsabilidad por los datos
+							revisados.
+						</span>
+					</label>
+				{/if}
+
+				{#if canCorrect}
+					<div class="actions">
+						<Button type="submit" disabled={!hasPendingModifications}>
+							Guardar modificaciones
+						</Button>
+					</div>
+				{:else}
+					<p class="hint">Los datos ya no se pueden corregir en este estado.</p>
+				{/if}
+			</form>
 		</CardContent>
 	</Card>
 
@@ -164,6 +654,16 @@ const statusTone = $derived(
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
+			{#if hasPendingModifications}
+				<div class="error-summary" role="alert">
+					<p class="error-summary-title">Hay modificaciones sin guardar</p>
+					<p class="error-text">
+						Guarda o descarta las modificaciones antes de confirmar la verificación. Si continúas
+						sin guardarlas, el certificado se emitiría con los datos guardados anteriormente.
+					</p>
+				</div>
+			{/if}
+
 			<form method="POST" action="?/save" class="stack">
 				<div class="check-list">
 					<label class="check-row">
@@ -172,6 +672,7 @@ const statusTone = $derived(
 							name="passportOrIdentityDocumentChecked"
 							value="yes"
 							checked={verification.passportOrIdentityDocumentChecked}
+							disabled={hasPendingModifications}
 							class="mt-1 size-4"
 						>
 						<span class="text-sm leading-6">
@@ -184,6 +685,7 @@ const statusTone = $derived(
 							name="userInformationConfirmed"
 							value="yes"
 							checked={verification.userInformationConfirmed}
+							disabled={hasPendingModifications}
 							class="mt-1 size-4"
 						>
 						<span class="text-sm leading-6">He confirmado estos datos con la persona.</span>
@@ -194,6 +696,7 @@ const statusTone = $derived(
 							name="vulnerabilityInformationReviewed"
 							value="yes"
 							checked={verification.vulnerabilityInformationReviewed}
+							disabled={hasPendingModifications}
 							class="mt-1 size-4"
 						>
 						<span class="text-sm leading-6">He revisado las circunstancias de vulnerabilidad.</span>
@@ -201,9 +704,14 @@ const statusTone = $derived(
 				</div>
 				<Separator />
 				<div class="actions">
-					<Button type="submit">Guardar confirmaciones</Button>
+					<Button type="submit" disabled={hasPendingModifications}>Guardar confirmaciones</Button>
 					{#if data.canMarkReadyToIssue}
-						<Button type="submit" formaction="?/ready" variant="secondary">
+						<Button
+							type="submit"
+							formaction="?/ready"
+							variant="secondary"
+							disabled={hasPendingModifications}
+						>
 							Marcar como lista para emitir
 						</Button>
 					{/if}
@@ -221,8 +729,18 @@ const statusTone = $derived(
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
+				{#if hasPendingModifications}
+					<div class="error-summary" role="alert">
+						<p class="error-summary-title">No se puede emitir con modificaciones sin guardar</p>
+						<p class="error-text">
+							Guarda o descarta las modificaciones antes de emitir el certificado.
+						</p>
+					</div>
+				{/if}
 				<form method="POST" action="?/issue">
-					<Button type="submit" variant="success">Emitir certificado</Button>
+					<Button type="submit" variant="success" disabled={hasPendingModifications}>
+						Emitir certificado
+					</Button>
 				</form>
 			</CardContent>
 		</Card>
@@ -247,3 +765,31 @@ const statusTone = $derived(
 		</Button>
 	</div>
 </div>
+
+<style>
+input[data-modified="true"],
+input[readonly][data-modified="true"] {
+	border-color: var(--color-warning, #b7791f);
+	background: color-mix(in srgb, var(--color-warning, #b7791f) 8%, transparent);
+}
+
+input[readonly] {
+	cursor: default;
+}
+
+.modified-note {
+	margin-top: 0.25rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--color-warning-text, #92400e);
+}
+
+.modified-summary-item {
+	display: grid;
+	gap: 0.25rem;
+	border-inline-start: 0.25rem solid var(--color-warning, #b7791f);
+	padding: 0.75rem;
+	background: color-mix(in srgb, var(--color-warning, #b7791f) 7%, transparent);
+	border-radius: 0.75rem;
+}
+</style>

--- a/docs/adr/019-organisation-review-corrections.md
+++ b/docs/adr/019-organisation-review-corrections.md
@@ -1,0 +1,105 @@
+# ADR 019: Allow audited organisation corrections during certificate review
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-06
+
+## Context
+
+Certificate drafts are prepared in the public Primer Paso service and handed off
+to a collaborating organisation for review.
+
+During an in-person review, the applicant may have entered incorrect,
+incomplete, or poorly formatted data. The organisation must be able to correct
+that data before approving the certificate for digital signature.
+
+However, the original applicant draft remains important evidence of what was
+submitted through the public service. The organisation must not silently mutate
+that original draft.
+
+This decision builds on:
+
+- ADR 014: token-based certificate handoff
+- ADR 016: certificate issuance belongs to the organisation portal
+- ADR 018: authenticated organisation review before certificate issue
+
+## Decision
+
+The organisation portal will allow controlled correction of certificate draft
+data during review.
+
+The original applicant draft is immutable and remains stored as
+`draft_snapshot`.
+
+Organisation-side corrections are applied only to `reviewed_data`.
+
+Every correction stores:
+
+- field path
+- previous value
+- corrected value
+- correction type
+- optional note
+- correcting member
+- timestamp
+
+Correction types are structured rather than free-text by default:
+
+- `typo`
+- `confirmed_with_applicant`
+- `document_verified`
+- `standardised_format`
+- `other`
+
+Free-text notes are optional and should be used only when the structured
+correction type is insufficient.
+
+Any correction resets review verification and returns the review to
+`in_review`. Verification must confirm the current reviewed data, not an older
+version of the data.
+
+Corrections are allowed only while the review is in `in_review`.
+
+Issued certificates are generated from `reviewed_data`, never directly from
+`draft_snapshot`.
+
+## Consequences
+
+The product supports real-world in-person interview workflows while preserving
+the boundary between applicant-submitted data and organisation-confirmed data.
+
+The organisation takes responsibility for corrected data by applying changes
+inside an authenticated, role-checked, audited review workflow.
+
+The review UI must expose when fields differ from the original draft.
+
+The database and repository layer must preserve correction history rather than
+only storing the latest reviewed state.
+
+Verification becomes tied to the reviewed data version. If the reviewed data is
+changed, previous verification is no longer valid.
+
+## Alternatives considered
+
+### Mutate the original draft
+
+Rejected because it destroys provenance and weakens the audit trail.
+
+### Do not allow corrections
+
+Rejected because it does not match in-person review reality and would lead to
+known errors being carried into issued certificates.
+
+### Require free-text correction reasons for every change
+
+Rejected because most correction reasons are low-signal in practice. Structured
+correction types are faster, more consistent, and easier to audit.
+
+## Review trigger
+
+Review this decision if legal guidance requires stronger evidence capture,
+separate signer review, attachment support, or tamper-evident audit storage.

--- a/packages/certificate/package.json
+++ b/packages/certificate/package.json
@@ -4,7 +4,8 @@
 	"version": "0.0.1",
 	"type": "module",
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.ts",
+		"./pdf": "./src/pdf.ts"
 	},
 	"scripts": {
 		"check": "biome check .",

--- a/packages/certificate/src/index.ts
+++ b/packages/certificate/src/index.ts
@@ -1,7 +1,5 @@
 export const CERTIFICATE_PACKAGE_VERSION = '0.0.1'
 
-export { generateVulnerabilityCertificatePdf } from './pdf'
-
 export type { CertificateDraftReviewField, CertificateDraftReviewFieldPath } from './schema'
 export {
 	CERTIFICATE_DRAFT_REVIEW_FIELDS,

--- a/packages/certificate/src/index.ts
+++ b/packages/certificate/src/index.ts
@@ -2,14 +2,18 @@ export const CERTIFICATE_PACKAGE_VERSION = '0.0.1'
 
 export { generateVulnerabilityCertificatePdf } from './pdf'
 
+export type { CertificateDraftReviewField, CertificateDraftReviewFieldPath } from './schema'
 export {
+	CERTIFICATE_DRAFT_REVIEW_FIELDS,
 	certificateDraftSchema,
 	certificateIssueRequestSchema,
+	getCertificateDraftReviewFieldValue,
 	isCertificateDraft,
 	parseCertificateDraft,
 	parseCertificateIssueRequest,
 	validateCertificateDraft,
-	validateCertificateIssueRequest
+	validateCertificateIssueRequest,
+	withCertificateDraftReviewDataFromForm
 } from './schema'
 export {
 	CERTIFICATE_SOURCE_TEMPLATE_FILENAME,

--- a/packages/certificate/src/schema.test.ts
+++ b/packages/certificate/src/schema.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import fixture from '../fixtures/vulnerability-certificate.issue-request.fixture.json'
 import {
+	CERTIFICATE_DRAFT_REVIEW_FIELDS,
 	certificateDraftSchema,
 	certificateIssueRequestSchema,
+	getCertificateDraftReviewFieldValue,
+	parseCertificateDraft,
 	parseCertificateIssueRequest,
 	validateCertificateDraft,
-	validateCertificateIssueRequest
+	validateCertificateIssueRequest,
+	withCertificateDraftReviewDataFromForm
 } from './schema'
 import { VULNERABILITY_REASON_VALUES } from './types'
 
@@ -107,5 +111,57 @@ describe('certificate schema', () => {
 		const result = validateCertificateDraft(fixture.draft)
 
 		expect(result.ok).toBe(true)
+	})
+
+	it('declares stable form field names for every reviewable draft field', () => {
+		expect(CERTIFICATE_DRAFT_REVIEW_FIELDS.map((field) => field.formName)).toEqual([
+			'givenNames',
+			'familyNames',
+			'documentType',
+			'documentNumber',
+			'dateOfBirth',
+			'nationality',
+			'email',
+			'phone',
+			'addressLine1',
+			'addressLine2',
+			'municipality',
+			'province',
+			'postalCode',
+			'vulnerabilityReasons'
+		])
+	})
+
+	it('reads reviewable values by path', () => {
+		const draft = parseCertificateDraft(fixture.draft)
+		expect(getCertificateDraftReviewFieldValue(draft, 'userData.identity.givenNames')).toBe('Amina')
+		expect(getCertificateDraftReviewFieldValue(draft, 'userData.vulnerability.reasons')).toEqual([
+			'vulnerable_family_unit',
+			'psychosocial_risks'
+		])
+	})
+
+	it('builds reviewed draft data from form fields', () => {
+		const draft = parseCertificateDraft(fixture.draft)
+		const formData = new FormData()
+		formData.set('givenNames', 'Aminata')
+		formData.set('familyNames', 'Benali')
+		formData.set('documentType', 'passport')
+		formData.set('documentNumber', 'P7654321')
+		formData.set('dateOfBirth', '1992-04-18')
+		formData.set('nationality', 'Marruecos')
+		formData.set('email', 'aminata@example.invalid')
+		formData.set('phone', '')
+		formData.set('addressLine1', 'Calle Nueva 1')
+		formData.set('addressLine2', '')
+		formData.set('municipality', 'Madrid')
+		formData.set('province', 'Madrid')
+		formData.set('postalCode', '28001')
+		formData.append('vulnerabilityReasons', 'psychosocial_risks')
+		const reviewed = withCertificateDraftReviewDataFromForm(draft, formData)
+		expect(reviewed.userData.identity.givenNames).toBe('Aminata')
+		expect(reviewed.userData.contact.phone).toBeUndefined()
+		expect(reviewed.userData.vulnerability.reasons).toEqual(['psychosocial_risks'])
+		expect(validateCertificateDraft(reviewed).ok).toBe(true)
 	})
 })

--- a/packages/certificate/src/schema.ts
+++ b/packages/certificate/src/schema.ts
@@ -3,10 +3,12 @@ import {
 	type CertificateDraft,
 	type CertificateIssueRequest,
 	DOCUMENT_TYPE_VALUES,
+	type DocumentType,
 	GENDER_MARKER_VALUES,
 	type ValidationIssue,
 	type ValidationResult,
-	VULNERABILITY_REASON_VALUES
+	VULNERABILITY_REASON_VALUES,
+	type VulnerabilityReason
 } from './types'
 
 type UnknownRecord = Record<string, unknown>
@@ -21,6 +23,58 @@ export interface FieldSchema {
 export interface ObjectSchema {
 	[key: string]: FieldSchema | ObjectSchema
 }
+
+export type CertificateDraftReviewFieldPath =
+	| 'userData.identity.givenNames'
+	| 'userData.identity.familyNames'
+	| 'userData.identity.documentType'
+	| 'userData.identity.documentNumber'
+	| 'userData.identity.dateOfBirth'
+	| 'userData.identity.nationality'
+	| 'userData.contact.email'
+	| 'userData.contact.phone'
+	| 'userData.location.addressLine1'
+	| 'userData.location.addressLine2'
+	| 'userData.location.municipality'
+	| 'userData.location.province'
+	| 'userData.location.postalCode'
+	| 'userData.vulnerability.reasons'
+
+export type CertificateDraftReviewFieldKind = 'string' | 'optional-string' | 'enum' | 'array'
+
+export interface CertificateDraftReviewField {
+	path: CertificateDraftReviewFieldPath
+	formName: string
+	kind: CertificateDraftReviewFieldKind
+	values?: readonly string[]
+}
+
+export const CERTIFICATE_DRAFT_REVIEW_FIELDS = [
+	{ path: 'userData.identity.givenNames', formName: 'givenNames', kind: 'string' },
+	{ path: 'userData.identity.familyNames', formName: 'familyNames', kind: 'string' },
+	{
+		path: 'userData.identity.documentType',
+		formName: 'documentType',
+		kind: 'enum',
+		values: DOCUMENT_TYPE_VALUES
+	},
+	{ path: 'userData.identity.documentNumber', formName: 'documentNumber', kind: 'string' },
+	{ path: 'userData.identity.dateOfBirth', formName: 'dateOfBirth', kind: 'optional-string' },
+	{ path: 'userData.identity.nationality', formName: 'nationality', kind: 'optional-string' },
+	{ path: 'userData.contact.email', formName: 'email', kind: 'string' },
+	{ path: 'userData.contact.phone', formName: 'phone', kind: 'optional-string' },
+	{ path: 'userData.location.addressLine1', formName: 'addressLine1', kind: 'string' },
+	{ path: 'userData.location.addressLine2', formName: 'addressLine2', kind: 'optional-string' },
+	{ path: 'userData.location.municipality', formName: 'municipality', kind: 'string' },
+	{ path: 'userData.location.province', formName: 'province', kind: 'string' },
+	{ path: 'userData.location.postalCode', formName: 'postalCode', kind: 'optional-string' },
+	{
+		path: 'userData.vulnerability.reasons',
+		formName: 'vulnerabilityReasons',
+		kind: 'array',
+		values: VULNERABILITY_REASON_VALUES
+	}
+] as const satisfies readonly CertificateDraftReviewField[]
 
 export const certificateDraftSchema = {
 	version: {
@@ -223,6 +277,88 @@ export const certificateIssueRequestSchema = {
 		description: 'ISO timestamp when the organisation issued the certificate.'
 	}
 } satisfies ObjectSchema
+
+const getString = (formData: FormData, name: string) => String(formData.get(name) ?? '').trim()
+
+const getOptionalString = (formData: FormData, name: string) => {
+	const value = getString(formData, name)
+	return value.length > 0 ? value : undefined
+}
+
+const getStringList = (formData: FormData, name: string) =>
+	formData.getAll(name).map(String).filter(Boolean)
+
+export const getCertificateDraftReviewFieldValue = (
+	draft: CertificateDraft,
+	path: CertificateDraftReviewFieldPath
+) => {
+	switch (path) {
+		case 'userData.identity.givenNames':
+			return draft.userData.identity.givenNames
+		case 'userData.identity.familyNames':
+			return draft.userData.identity.familyNames
+		case 'userData.identity.documentType':
+			return draft.userData.identity.documentType
+		case 'userData.identity.documentNumber':
+			return draft.userData.identity.documentNumber
+		case 'userData.identity.dateOfBirth':
+			return draft.userData.identity.dateOfBirth
+		case 'userData.identity.nationality':
+			return draft.userData.identity.nationality
+		case 'userData.contact.email':
+			return draft.userData.contact.email
+		case 'userData.contact.phone':
+			return draft.userData.contact.phone
+		case 'userData.location.addressLine1':
+			return draft.userData.location.addressLine1
+		case 'userData.location.addressLine2':
+			return draft.userData.location.addressLine2
+		case 'userData.location.municipality':
+			return draft.userData.location.municipality
+		case 'userData.location.province':
+			return draft.userData.location.province
+		case 'userData.location.postalCode':
+			return draft.userData.location.postalCode
+		case 'userData.vulnerability.reasons':
+			return draft.userData.vulnerability.reasons
+	}
+}
+
+export const withCertificateDraftReviewDataFromForm = (
+	draft: CertificateDraft,
+	formData: FormData
+): CertificateDraft => ({
+	...draft,
+	userData: {
+		...draft.userData,
+		identity: {
+			...draft.userData.identity,
+			givenNames: getString(formData, 'givenNames'),
+			familyNames: getString(formData, 'familyNames'),
+			documentType: getString(formData, 'documentType') as DocumentType,
+			documentNumber: getString(formData, 'documentNumber'),
+			dateOfBirth: getOptionalString(formData, 'dateOfBirth'),
+			nationality: getOptionalString(formData, 'nationality')
+		},
+		contact: {
+			...draft.userData.contact,
+			email: getString(formData, 'email'),
+			phone: getOptionalString(formData, 'phone')
+		},
+		location: {
+			...draft.userData.location,
+			addressLine1: getString(formData, 'addressLine1'),
+			addressLine2: getOptionalString(formData, 'addressLine2'),
+			municipality: getString(formData, 'municipality'),
+			province: getString(formData, 'province'),
+			postalCode: getOptionalString(formData, 'postalCode')
+		},
+		vulnerability: {
+			...draft.userData.vulnerability,
+			reasons: getStringList(formData, 'vulnerabilityReasons') as VulnerabilityReason[]
+		}
+	}
+})
 
 const isRecord = (value: unknown): value is UnknownRecord =>
 	Boolean(value) && typeof value === 'object' && !Array.isArray(value)

--- a/packages/db/src/database.types.ts
+++ b/packages/db/src/database.types.ts
@@ -73,6 +73,7 @@ export type Database = {
 			}
 			certificate_handoff_reviews: {
 				Row: {
+					corrections: Json
 					created_at: string
 					draft_snapshot: Json
 					handoff_id: string
@@ -87,6 +88,7 @@ export type Database = {
 					verification: Json | null
 				}
 				Insert: {
+					corrections?: Json
 					created_at?: string
 					draft_snapshot: Json
 					handoff_id: string
@@ -101,6 +103,7 @@ export type Database = {
 					verification?: Json | null
 				}
 				Update: {
+					corrections?: Json
 					created_at?: string
 					draft_snapshot?: Json
 					handoff_id?: string

--- a/packages/db/src/org-portal.ts
+++ b/packages/db/src/org-portal.ts
@@ -15,6 +15,12 @@ import {
 
 export type OrganisationMemberStatus = 'invited' | 'active' | 'disabled'
 export type CertificateHandoffReviewStatus = 'in_review' | 'ready_to_issue' | 'issued' | 'cancelled'
+export type CertificateCorrectionType =
+	| 'typo'
+	| 'confirmed_with_applicant'
+	| 'document_verified'
+	| 'standardised_format'
+	| 'other'
 
 export interface OrganisationRecord {
 	id: string
@@ -78,6 +84,16 @@ export interface VerificationReview {
 	vulnerabilityInformationReviewed: boolean
 }
 
+export interface CertificateFieldCorrection {
+	fieldPath: string
+	from: JSONValue
+	to: JSONValue
+	type: CertificateCorrectionType
+	note?: string
+	correctedByMemberId: string
+	correctedAt: string
+}
+
 export interface CertificateHandoffReviewRecord {
 	id: string
 	handoffId: string
@@ -87,6 +103,7 @@ export interface CertificateHandoffReviewRecord {
 	draftSnapshot: CertificateDraft
 	reviewedData: CertificateDraft
 	verification?: VerificationReview
+	corrections: CertificateFieldCorrection[]
 	createdAt: string
 	updatedAt: string
 	readyToIssueAt?: string
@@ -251,6 +268,14 @@ export interface UpdateCertificateHandoffReviewVerificationInput {
 	now?: Date
 }
 
+export interface UpdateCertificateHandoffReviewReviewedDataInput {
+	reviewId: string
+	memberId: string
+	reviewedData: CertificateDraft
+	corrections: Omit<CertificateFieldCorrection, 'correctedByMemberId' | 'correctedAt'>[]
+	now?: Date
+}
+
 export interface OrgPortalRepository {
 	updateOrganisationProfile: (input: UpdateOrganisationProfileInput) => Promise<OrganisationRecord>
 	findOrganisationById: (id: string) => Promise<OrganisationRecord | null>
@@ -283,6 +308,9 @@ export interface OrgPortalRepository {
 	findCertificateHandoffReviewById: (id: string) => Promise<CertificateHandoffReviewRecord | null>
 	updateCertificateHandoffReviewVerification: (
 		input: UpdateCertificateHandoffReviewVerificationInput
+	) => Promise<CertificateHandoffReviewRecord | null>
+	updateCertificateHandoffReviewReviewedData: (
+		input: UpdateCertificateHandoffReviewReviewedDataInput
 	) => Promise<CertificateHandoffReviewRecord | null>
 	createIssuedCertificate: (input: CreateIssuedCertificateInput) => Promise<IssuedCertificateRecord>
 	findIssuedCertificateByReviewId: (reviewId: string) => Promise<IssuedCertificateRecord | null>
@@ -390,6 +418,7 @@ const reviewFromRow = (row: Record<string, unknown>): CertificateHandoffReviewRe
 	draftSnapshot: row.draft_snapshot as CertificateDraft,
 	reviewedData: row.reviewed_data as CertificateDraft,
 	verification: row.verification as VerificationReview | undefined,
+	corrections: (row.corrections ?? []) as CertificateFieldCorrection[],
 	createdAt: date(row.created_at),
 	updatedAt: date(row.updated_at),
 	readyToIssueAt: optionalDate(row.ready_to_issue_at),
@@ -967,6 +996,37 @@ export const createPostgresOrgPortalRepository = ({
 					updated_at = ${now.toISOString()},
 					ready_to_issue_at = coalesce(ready_to_issue_at, ${readyToIssueAt})
 				where id = ${reviewId}
+				returning *
+			`
+
+			return rows[0] ? reviewFromRow(rows[0]) : null
+		},
+
+		updateCertificateHandoffReviewReviewedData: async ({
+			reviewId,
+			memberId,
+			reviewedData,
+			corrections,
+			now = new Date()
+		}) => {
+			const correctedAt = now.toISOString()
+			const persistedCorrections = corrections.map((correction) => ({
+				...correction,
+				correctedByMemberId: memberId,
+				correctedAt
+			}))
+
+			const rows = await sql`
+				update certificate_handoff_reviews
+				set
+					reviewed_data = ${sql.json(toJsonValue(reviewedData))},
+					corrections = corrections || ${sql.json(toJsonValue(persistedCorrections))},
+					verification = null,
+					status = 'in_review',
+					ready_to_issue_at = null,
+					updated_at = ${now.toISOString()}
+				where id = ${reviewId}
+					and status = 'in_review'
 				returning *
 			`
 

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -8,7 +8,7 @@
 		"files": true,
 		"removeComments": true,
 		"removeEmptyLines": true,
-		"compress": false,
+		"compress": true,
 		"topFilesLength": 5
 	}
 }

--- a/supabase/migrations/007_review_corrections.sql
+++ b/supabase/migrations/007_review_corrections.sql
@@ -1,0 +1,6 @@
+alter table certificate_handoff_reviews
+	add column if not exists corrections jsonb not null default '[]'::jsonb;
+
+create index if not exists certificate_handoff_reviews_corrections_gin_idx
+	on certificate_handoff_reviews
+	using gin (corrections);


### PR DESCRIPTION
## What changed?

Added support for users in the org-portal to modify certificates that arrive through the handover.

## Risk level

- [ ] Low: copy, docs, styling, tests only
- [ ] Medium: app logic, validation, routing, dependencies
- [x] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


