### PR TITLE
fix(public): download pdf from results page

### DIFF
--- a/apps/public/src/routes/[lang=lang]/result/+page.svelte
+++ b/apps/public/src/routes/[lang=lang]/result/+page.svelte
@@ -73,6 +73,8 @@ const startAgainHref = $derived(localiseHref(data.locale ?? 'es', '/screener?new
 					<Button
 						href={data.handoverHref}
 						variant="secondary"
+						data-sveltekit-reload
+						download
 						onclick={() =>
 							trackEvent('Journey', 'Download handover PDF', data.result.resultState)}
 					>
@@ -254,6 +256,8 @@ const startAgainHref = $derived(localiseHref(data.locale ?? 'es', '/screener?new
 					<Button
 						href={data.handoverHref}
 						variant="secondary"
+						data-sveltekit-reload
+						download
 						onclick={() =>
 							trackEvent('Journey', 'Download handover PDF', data.result.resultState)}
 					>


### PR DESCRIPTION
## Bug Fix
"Download handover PDF" button on  the result page currently throwing 404.

### Reason
SvelteKit intercepts same-origin link clicks and tries to  handle them through its client-side router. The router only knows how to render +page routes — a raw PDF response from a +server.ts endpoint has no page component, so the navigation throws a 404.


### Proposed Solution
 Adds **data-sveltekit-reload** and **download** attributes to the two handover-PDF <Button> links on the result page 
  - **data-sveltekit-reload** bypasses SvelteKit's client-side router to prevent a real navigation to the PDF URL
  - **download** hints to save rather than render in-tab.
  



