### PR TITLE
feat(public): add visual qa for screener pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 .svelte-kit
 /build
 apps/*/build
+apps/public/visual-output/
 
 # OS
 .DS_Store

--- a/apps/public/package.json
+++ b/apps/public/package.json
@@ -18,7 +18,8 @@
 		"check": "biome check .",
 		"typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"test": "node --env-file=../../.env.test ./node_modules/vitest/vitest.mjs run",
-		"test:watch": "node --env-file=../../.env.test ./node_modules/vitest/vitest.mjs"
+		"test:watch": "node --env-file=../../.env.test ./node_modules/vitest/vitest.mjs",
+		"visual:screener": "tsx scripts/capture-screener-visuals.ts"
 	},
 	"dependencies": {
 		"@fontsource-variable/inter": "^5.2.8",
@@ -38,6 +39,7 @@
 		"tw-animate-css": "^1.4.0"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.56.0",
 		"@biomejs/biome": "2.4.14",
 		"@sveltejs/adapter-netlify": "latest",
 		"@sveltejs/kit": "latest",
@@ -49,6 +51,7 @@
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.7",
 		"tailwindcss": "^4.2.4",
+		"tsx": "^4.20.6",
 		"typescript": "^6.0.3",
 		"vite": "^8.0.10",
 		"vitest": "^4.1.5"

--- a/apps/public/scripts/capture-screener-visuals.ts
+++ b/apps/public/scripts/capture-screener-visuals.ts
@@ -1,0 +1,334 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { type BrowserContext, chromium, type Page } from '@playwright/test'
+import { VULNERABILITY_REASON_VALUES } from '@primer-paso/certificate'
+
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:5173'
+const LOCALE = process.env.LOCALE ?? 'es'
+const OUT_DIR = path.resolve('visual-output/screener')
+const JOURNEY_COOKIE = 'ri_journey'
+
+type CriminalRecordCertificateStatus =
+	| 'already_have'
+	| 'requested_waiting'
+	| 'not_requested_yet'
+	| 'not_sure'
+
+type PreviousResidenceCountry = {
+	countryCode: string
+	certificateStatus?: CriminalRecordCertificateStatus
+}
+
+type VisualAnswers = Record<string, unknown>
+
+type VisualVariant = {
+	name: string
+	pathname: string
+	answers?: VisualAnswers
+}
+
+const now = () => new Date().toISOString()
+
+const makeJourneyState = (answers: VisualAnswers = {}) => ({
+	sessionId: 'visual-qa-session',
+	answers,
+	updatedAt: now()
+})
+
+const baseAnswers: VisualAnswers = {
+	presentBeforeCutoff: 'yes',
+	asylumHistory: 'no',
+	fiveMonthStay: 'yes',
+	familySituation: ['none'],
+	workSituation: ['worked_in_spain'],
+	vulnerabilitySituation: ['none'],
+	identityDocuments: ['current_passport'],
+	previousResidenceCountries: [{ countryCode: 'ES' }],
+	evidenceBeforeCutoff: ['padron_or_registration'],
+	evidenceRecentMonths: ['housing_papers'],
+	supportNeeds: ['none'],
+	specialistFlags: ['none'],
+	province: '28'
+}
+
+const asylumRouteAnswers: VisualAnswers = {
+	presentBeforeCutoff: 'yes',
+	asylumHistory: 'yes',
+	asylumBeforeCutoff: 'yes',
+	identityDocuments: ['asylum_document'],
+	previousResidenceCountries: [{ countryCode: 'ES' }],
+	evidenceBeforeCutoff: ['padron_or_registration'],
+	evidenceRecentMonths: ['housing_papers'],
+	asylumCaseDocuments: 'yes',
+	supportNeeds: ['none'],
+	specialistFlags: ['none'],
+	province: '28'
+}
+
+const familyRouteAnswers: VisualAnswers = {
+	...baseAnswers,
+	workSituation: ['none'],
+	familySituation: ['child_under_18'],
+	vulnerabilitySituation: ['none']
+}
+
+const workRouteAnswers: VisualAnswers = {
+	...baseAnswers,
+	workSituation: ['worked_in_spain'],
+	familySituation: ['none'],
+	vulnerabilitySituation: ['none']
+}
+
+const vulnerabilityPositiveRouteAnswers: VisualAnswers = {
+	...baseAnswers,
+	workSituation: ['none'],
+	familySituation: ['none'],
+	vulnerabilitySituation: [VULNERABILITY_REASON_VALUES[0]]
+}
+
+const specialistReviewAnswers: VisualAnswers = {
+	...baseAnswers,
+	presentBeforeCutoff: 'not_sure',
+	asylumHistory: 'no',
+	fiveMonthStay: 'yes',
+	workSituation: ['none'],
+	familySituation: ['none'],
+	vulnerabilitySituation: ['none'],
+	identityDocuments: ['current_passport'],
+	evidenceBeforeCutoff: ['padron_or_registration'],
+	evidenceRecentMonths: ['housing_papers'],
+	supportNeeds: ['specialist_advice'],
+	specialistFlags: ['want_specialist']
+}
+
+const notThisProcessAnswers: VisualAnswers = {
+	...baseAnswers,
+	presentBeforeCutoff: 'no',
+	asylumHistory: 'no',
+	fiveMonthStay: 'yes',
+	workSituation: ['none'],
+	familySituation: ['none'],
+	vulnerabilitySituation: ['none'],
+	specialistFlags: ['none']
+}
+
+const criminalRecordActionAnswers: VisualAnswers = {
+	...baseAnswers,
+	previousResidenceCountries: [
+		{ countryCode: 'ES' },
+		{ countryCode: 'FR', certificateStatus: 'not_requested_yet' },
+		{ countryCode: 'MA', certificateStatus: 'requested_waiting' },
+		{ countryCode: 'CO', certificateStatus: 'already_have' },
+		{ countryCode: 'AR', certificateStatus: 'not_sure' }
+	] satisfies PreviousResidenceCountry[]
+}
+
+const ordinaryPages: VisualVariant[] = [
+	{ name: '00-screener', pathname: '/screener', answers: {} },
+	{ name: '01-presence-before-cutoff', pathname: '/presence-before-cutoff' },
+	{ name: '02-asylum-history', pathname: '/asylum-history' },
+	{
+		name: '03-asylum-before-cutoff',
+		pathname: '/asylum-before-cutoff',
+		answers: { ...baseAnswers, asylumHistory: 'yes' }
+	},
+	{ name: '04-five-month-stay', pathname: '/five-month-stay' },
+	{ name: '05-family-situation', pathname: '/family-situation' },
+	{ name: '06-work-situation', pathname: '/work-situation' },
+	{ name: '07-vulnerability-situation', pathname: '/vulnerability-situation' },
+	{ name: '08-identity-documents', pathname: '/identity-documents' },
+	{
+		name: '09-previous-residence-countries',
+		pathname: '/previous-residence-countries'
+	},
+	{ name: '11-evidence-before-cutoff', pathname: '/evidence-before-cutoff' },
+	{ name: '12-evidence-recent-months', pathname: '/evidence-recent-months' },
+	{
+		name: '13-asylum-documents',
+		pathname: '/asylum-documents',
+		answers: asylumRouteAnswers
+	},
+	{ name: '14-support-needs', pathname: '/support-needs' },
+	{ name: '15-specialist-flags', pathname: '/specialist-flags' },
+	{ name: '16-province', pathname: '/province' },
+	{
+		name: '17-check-answers',
+		pathname: '/check-answers',
+		answers: criminalRecordActionAnswers
+	}
+]
+
+const criminalRecordPages: VisualVariant[] = [
+	{
+		name: '10a-criminal-record-certificates-one-country',
+		pathname: '/criminal-record-certificates',
+		answers: {
+			...baseAnswers,
+			previousResidenceCountries: [{ countryCode: 'ES' }, { countryCode: 'FR' }]
+		}
+	},
+	{
+		name: '10b-criminal-record-certificates-many-countries',
+		pathname: '/criminal-record-certificates',
+		answers: {
+			...baseAnswers,
+			previousResidenceCountries: [
+				{ countryCode: 'ES' },
+				{ countryCode: 'FR' },
+				{ countryCode: 'MA' },
+				{ countryCode: 'CO' },
+				{ countryCode: 'AR' }
+			]
+		}
+	},
+	{
+		name: '10c-criminal-record-certificates-prefilled',
+		pathname: '/criminal-record-certificates',
+		answers: criminalRecordActionAnswers
+	}
+]
+
+const resultPages: VisualVariant[] = [
+	{
+		name: '18a-result-eligible-international-protection',
+		pathname: '/result',
+		answers: asylumRouteAnswers
+	},
+	{
+		name: '18b-result-eligible-family-unit',
+		pathname: '/result',
+		answers: familyRouteAnswers
+	},
+	{
+		name: '18c-result-eligible-work-or-intention',
+		pathname: '/result',
+		answers: workRouteAnswers
+	},
+	{
+		name: '18d-result-eligible-vulnerability',
+		pathname: '/result',
+		answers: vulnerabilityPositiveRouteAnswers
+	},
+	{
+		name: '18e-result-needs-specialist-review',
+		pathname: '/result',
+		answers: specialistReviewAnswers
+	},
+	{
+		name: '18f-result-not-this-process',
+		pathname: '/result',
+		answers: notThisProcessAnswers
+	},
+	{
+		name: '18g-result-criminal-record-actions',
+		pathname: '/result',
+		answers: criminalRecordActionAnswers
+	}
+]
+
+async function prepareOutput() {
+	await fs.rm(OUT_DIR, { recursive: true, force: true })
+	await fs.mkdir(OUT_DIR, { recursive: true })
+}
+
+async function setJourneyState(context: BrowserContext, answers: VisualAnswers) {
+	const url = new URL(BASE_URL)
+	const state = makeJourneyState(answers)
+	const value = JSON.stringify(state)
+
+	await context.clearCookies()
+
+	await context.addCookies([
+		{
+			name: JOURNEY_COOKIE,
+			value,
+			domain: url.hostname,
+			path: '/',
+			httpOnly: true,
+			sameSite: 'Lax',
+			secure: url.protocol === 'https:'
+		}
+	])
+
+	const storedCookies = await context.cookies(BASE_URL)
+	const storedJourneyCookie = storedCookies.find((cookie) => cookie.name === JOURNEY_COOKIE)
+
+	console.log('[visual:screener] set journey cookie', {
+		baseUrl: BASE_URL,
+		host: url.hostname,
+		secure: url.protocol === 'https:',
+		answerKeys: Object.keys(answers),
+		state,
+		rawValueLength: value.length,
+		storedCookie: storedJourneyCookie
+			? {
+					name: storedJourneyCookie.name,
+					domain: storedJourneyCookie.domain,
+					path: storedJourneyCookie.path,
+					httpOnly: storedJourneyCookie.httpOnly,
+					secure: storedJourneyCookie.secure,
+					sameSite: storedJourneyCookie.sameSite,
+					valueLength: storedJourneyCookie.value.length,
+					valueStart: storedJourneyCookie.value.slice(0, 120)
+				}
+			: null
+	})
+}
+
+async function screenshot(page: Page, name: string) {
+	await page.screenshot({
+		path: path.join(OUT_DIR, `${name}.png`),
+		fullPage: true
+	})
+}
+
+async function captureVariant(page: Page, context: BrowserContext, variant: VisualVariant) {
+	const answers = variant.answers ?? baseAnswers
+	await setJourneyState(context, answers)
+
+	console.log('[visual:screener] visiting', {
+		name: variant.name,
+		expectedPathname: variant.pathname,
+		url: `${BASE_URL}/${LOCALE}${variant.pathname}`
+	})
+
+	await page.goto(`${BASE_URL}/${LOCALE}${variant.pathname}`)
+	await page.waitForLoadState('networkidle')
+
+	const finalPathname = new URL(page.url()).pathname
+
+	console.log('[visual:screener] visited', {
+		name: variant.name,
+		finalUrl: page.url(),
+		finalPathname
+	})
+
+	if (!finalPathname.endsWith(`/${LOCALE}${variant.pathname}`)) {
+		console.warn(`Expected ${variant.pathname}, but landed on ${finalPathname}. Capturing anyway.`)
+	}
+	await screenshot(page, variant.name)
+}
+
+async function run() {
+	await prepareOutput()
+	const browser = await chromium.launch()
+	const context = await browser.newContext({
+		viewport: {
+			width: 1440,
+			height: 1200
+		}
+	})
+	const page = await context.newPage()
+
+	for (const variant of [...ordinaryPages, ...criminalRecordPages, ...resultPages]) {
+		await captureVariant(page, context, variant)
+	}
+
+	await browser.close()
+	console.log(`Wrote screener screenshots to ${OUT_DIR}`)
+}
+
+run().catch((error) => {
+	console.error(error)
+	process.exit(1)
+})

--- a/apps/public/src/lib/server/journey.ts
+++ b/apps/public/src/lib/server/journey.ts
@@ -122,18 +122,70 @@ export const hasStartedJourney = (answers: JourneyAnswers) => {
 	return Object.values(screenerAnswers).some(isMeaningfulAnswer)
 }
 
+const shouldDebugJourneyCookie = () =>
+	process.env.DEBUG_JOURNEY_COOKIE === '1' || process.env.DEBUG_VISUAL_SCREENER === '1'
+
+const debugJourneyCookie = (message: string, details: Record<string, unknown> = {}) => {
+	if (!shouldDebugJourneyCookie()) return
+
+	console.log(`[journey-cookie] ${message}`, details)
+}
+
 export const getJourneyState = (cookies: Cookies) => {
 	const raw = cookies.get(JOURNEY_COOKIE)
 
 	if (!raw) {
+		debugJourneyCookie('missing cookie', {
+			cookieName: JOURNEY_COOKIE
+		})
+
 		return createEmptyState()
 	}
 
+	debugJourneyCookie('raw cookie found', {
+		cookieName: JOURNEY_COOKIE,
+		rawLength: raw.length,
+		rawStart: raw.slice(0, 160)
+	})
+
 	try {
 		const parsed = JSON.parse(raw)
+		const valid = isJourneyState(parsed)
 
-		return isJourneyState(parsed) ? parsed : createEmptyState()
-	} catch {
+		debugJourneyCookie('parsed cookie', {
+			valid,
+			parsedType: typeof parsed,
+			sessionId:
+				parsed && typeof parsed === 'object'
+					? (parsed as Record<string, unknown>).sessionId
+					: undefined,
+			updatedAt:
+				parsed && typeof parsed === 'object'
+					? (parsed as Record<string, unknown>).updatedAt
+					: undefined,
+			answerKeys:
+				parsed &&
+				typeof parsed === 'object' &&
+				(parsed as Record<string, unknown>).answers &&
+				typeof (parsed as Record<string, unknown>).answers === 'object'
+					? Object.keys((parsed as Record<string, Record<string, unknown>>).answers)
+					: undefined,
+			answers:
+				parsed && typeof parsed === 'object'
+					? (parsed as Record<string, unknown>).answers
+					: undefined
+		})
+
+		if (valid) return parsed
+
+		debugJourneyCookie('cookie failed journey state validation')
+
+		return createEmptyState()
+	} catch (error) {
+		debugJourneyCookie('cookie JSON parse failed', {
+			error: error instanceof Error ? error.message : String(error)
+		})
+
 		return createEmptyState()
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.14
         version: 2.4.14
+      '@playwright/test':
+        specifier: ^1.56.0
+        version: 1.60.0
       '@sveltejs/adapter-netlify':
         specifier: latest
         version: 6.0.4(@sveltejs/kit@2.59.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.58.2))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))(svelte@5.55.5(@typescript-eslint/types@8.58.2))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
@@ -190,6 +193,9 @@ importers:
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1899,6 +1905,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -4252,6 +4263,11 @@ packages:
   from2@2.3.0:
     resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -6024,6 +6040,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -9454,6 +9480,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -12026,6 +12056,9 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -14385,6 +14418,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 


### PR DESCRIPTION
## What changed?


## Risk level

- [ ] Low: copy, docs, styling, tests only
- [x] Medium: app logic, validation, routing, dependencies
- [ ] High: auth, database, migrations, CI/CD, deployment, secrets, tenant isolation, certificate generation, signing, or data retention

## Checks

- [x] I ran the relevant checks locally
- [x] I considered privacy/data exposure
- [x] I added or updated tests where behaviour changed

## Notes


